### PR TITLE
Remove duplicate alias to nrepl in client

### DIFF
--- a/src/drawbridge/client.clj
+++ b/src/drawbridge/client.clj
@@ -2,8 +2,7 @@
   (:require
    [cheshire.core :as json]
    [clojure.java.io :as io]
-   [clj-http.client :as http]
-   [nrepl.core :as nrepl])
+   [clj-http.client :as http])
   (:import
    (java.util.concurrent LinkedBlockingQueue TimeUnit)))
 


### PR DESCRIPTION
This PR fixes a duplicate alias to `nrepl` in the client that caused an illegal state exception.