### PR TITLE
[Fix #28] Move back to FnTransport for transport creation

### DIFF
--- a/src/drawbridge/client.clj
+++ b/src/drawbridge/client.clj
@@ -45,7 +45,7 @@
                                                              (when msg {:form-params msg})))]
                  (swap! session-cookies merge cookies)
                  (fill body)))]
-    (transport/fn-transport
+    (transport/FnTransport.
      (fn read [timeout]
        (let [t (System/currentTimeMillis)]
          (or (.poll incoming 0 TimeUnit/MILLISECONDS)


### PR DESCRIPTION
This PR fixes issue #28 by moving back to `FnTransport` instead of `fn-transport` for transport creation.