### PR TITLE
Add smoke test for the Drawbridge client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ pom.xml
 .lein-plugins
 .lein-repl-history
 .nrepl-history
+.nrepl-port
 .classpath
 .project
 .settings

--- a/project.clj
+++ b/project.clj
@@ -11,13 +11,16 @@
                  ;; client
                  [clj-http "3.9.1"]]
 
+  :aliases {"test-all" ["with-profile" "+1.8:+1.9" "test"]}
+
   :deploy-repositories [["clojars" {:url "https://clojars.org/repo"
                                     :username :env/clojars_username
                                     :password :env/clojars_password
                                     :sign-releases false}]]
 
-  :dev-dependencies [[ring "1.7.1"]]
-  :profiles {:dev {:dependencies [[ring "1.7.1"]]}
+  :profiles {:dev {:dependencies [[compojure "1.6.1"]
+                                  [http-kit "2.2.0"]
+                                  [ring "1.7.1"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
 

--- a/test/drawbridge/client_test.clj
+++ b/test/drawbridge/client_test.clj
@@ -19,21 +19,33 @@
 
 (use-fixtures :once server-fixture)
 
+(defn without-unstable-keys
+  [res]
+  (map #(dissoc % :id :session) res))
+
 (defn send-message
   [client message]
   (-> client
       (nrepl/message message)
-      nrepl/response-values
-      last))
+      without-unstable-keys
+      first))
 
 (deftest sending-messages
   (with-open [conn (nrepl/url-connect "http://localhost:12345/repl")]
     (let [client (nrepl/client conn 1000)]
-      (testing "Evaluating valid form returns the result"
-        (is (= 3 (send-message client {:op "eval" :code "(+ 1 2)"}))))
+      (testing "Evaluating a valid form returns the value"
+        (is (= {:value "3"
+                :ns    "user"}
+               (send-message client {:op "eval" :code "(+ 1 2)"}))))
 
-      (testing "Evaluating invalid form returns nil"
-        (is (nil? (send-message client {:op "eval" :code "(+ 1 2"}))))
+      (testing "Evaluating an invalid form returns an error"
+        (is (= {:status  ["eval-error"]
+                :ex      "class clojure.lang.LispReader$ReaderException"
+                :root-ex "class java.lang.RuntimeException"}
+               (send-message client {:op "eval" :code "(+ 1 2"}))))
 
-      (testing "Evaluating a form that throws returns nil"
-        (is (nil? (send-message client {:op "eval" :code "(throw (ex-info nil {:foo :bar}))"})))))))
+      (testing "Evaluating a form that throws returns an error"
+        (is (= {:status  ["eval-error"]
+                :ex      "class clojure.lang.ExceptionInfo"
+                :root-ex "class clojure.lang.ExceptionInfo"}
+               (send-message client {:op "eval" :code "(throw (ex-info nil {:foo :bar}))"})))))))

--- a/test/drawbridge/client_test.clj
+++ b/test/drawbridge/client_test.clj
@@ -1,0 +1,39 @@
+(ns drawbridge.client-test
+  (:require [clojure.test :refer [deftest is use-fixtures testing]]
+            [compojure.core :refer [ANY defroutes]]
+            [compojure.handler :as handler]
+            [drawbridge.core :as drawbridge]
+            [drawbridge.client]
+            [nrepl.core :as nrepl]
+            [org.httpkit.server :as server]))
+
+(let [nrepl-handler (drawbridge/ring-handler)]
+  (defroutes app
+    (ANY "/repl" request (nrepl-handler request))))
+
+(defn server-fixture
+  [f]
+  (let [stop-fn (server/run-server (handler/api #'app) {:port 12345})]
+    (f)
+    (stop-fn)))
+
+(use-fixtures :once server-fixture)
+
+(defn send-message
+  [client message]
+  (-> client
+      (nrepl/message message)
+      nrepl/response-values
+      last))
+
+(deftest sending-messages
+  (with-open [conn (nrepl/url-connect "http://localhost:12345/repl")]
+    (let [client (nrepl/client conn 1000)]
+      (testing "Evaluating valid form returns the result"
+        (is (= 3 (send-message client {:op "eval" :code "(+ 1 2)"}))))
+
+      (testing "Evaluating invalid form returns nil"
+        (is (nil? (send-message client {:op "eval" :code "(+ 1 2"}))))
+
+      (testing "Evaluating a form that throws returns nil"
+        (is (nil? (send-message client {:op "eval" :code "(throw (ex-info nil {:foo :bar}))"})))))))


### PR DESCRIPTION
I don't know nREPL very well, so this is an extremely basic set of assertions. It's basically just a starting point. It should prevent bugs like #28 from occurring, at least.

Potential future improvements:
- Test the Drawbridge Ring handler with [ring-mock](https://github.com/ring-clojure/ring-mock)
- Test other nREPL operations besides `eval`