### PR TITLE
Fix tests for clojure 1.7

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                  ;; client
                  [clj-http "3.9.1"]]
 
-  :aliases {"test-all" ["with-profile" "+1.8:+1.9" "test"]}
+  :aliases {"test-all" ["with-profile" "+1.7:+1.8:+1.9" "test"]}
 
   :deploy-repositories [["clojars" {:url "https://clojars.org/repo"
                                     :username :env/clojars_username
@@ -20,8 +20,9 @@
                                     :sign-releases false}]]
 
   :profiles {:dev {:dependencies [[compojure "1.6.1"]
-                                  [aleph "0.4.6"]
+                                  [aleph "0.4.4"]
                                   [ring "1.7.1"]]}
+             :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
 

--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
                                     :sign-releases false}]]
 
   :profiles {:dev {:dependencies [[compojure "1.6.1"]
-                                  [aleph "0.4.4"]
+                                  [ring/ring-jetty-adapter "1.7.1"]
                                   [ring "1.7.1"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}

--- a/test/drawbridge/client_test.clj
+++ b/test/drawbridge/client_test.clj
@@ -5,7 +5,7 @@
             [drawbridge.core :as drawbridge]
             [drawbridge.client]
             [nrepl.core :as nrepl]
-            [aleph.http :as http]))
+            [ring.adapter.jetty :as jetty]))
 
 (let [nrepl-handler (drawbridge/ring-handler)]
   (defroutes app
@@ -13,9 +13,9 @@
 
 (defn server-fixture
   [f]
-  (let [server (http/start-server (handler/api #'app) {:port 12345})]
+  (let [server (jetty/run-jetty (handler/api #'app) {:port 12345 :join? false})]
     (f)
-    (.close server)))
+    (.stop server)))
 
 (use-fixtures :once server-fixture)
 


### PR DESCRIPTION
This PR fixes the tests for clojure 1.7 by downgrading the aleph dependency to 0.4.4.