### PR TITLE
use nREPL 0.6.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject nrepl/drawbridge "0.2.0"
+(defproject nrepl/drawbridge "0.2.1-SNAPSHOT"
   :description "HTTP transport support for Clojure's nREPL implemented as a Ring handler."
   :url "http://github.com/nrepl/drawbridge"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git" :url "https://github.com/nrepl/drawbridge"}
-  :dependencies [[nrepl "0.5.3"]
+  :dependencies [[nrepl "0.6.0"]
                  [ring/ring-core "1.7.1"]
                  [cheshire "5.8.1"]
                  ;; client

--- a/test/drawbridge/client_test.clj
+++ b/test/drawbridge/client_test.clj
@@ -39,10 +39,14 @@
                (send-message client {:op "eval" :code "(+ 1 2)"}))))
 
       (testing "Evaluating an invalid form returns an error"
-        (is (= {:err "Syntax error reading source at (REPL:1:1).\nEOF while reading, starting at line 1\n"}
+        (is (= (if (< (:minor *clojure-version*) 10)
+                   {:err "RuntimeException EOF while reading, starting at line 1  clojure.lang.Util.runtimeException (Util.java:221)\n"}
+                   {:err "Syntax error reading source at (REPL:1:1).\nEOF while reading, starting at line 1\n"})
                (send-message client {:op "eval" :code "(+ 1 2"}))))
 
       (testing "Evaluating a form that throws returns an error"
-        (is (clojure.string/starts-with?
+        (is (.startsWith
               (:err (send-message client {:op "eval" :code "(throw (ex-info nil {:foo :bar}))"}))
-              "Execution error (ExceptionInfo) at user/eval"))))))
+              (if (< (:minor *clojure-version*) 10)
+                  "ExceptionInfo   clojure.core/ex-info (core.clj"
+                  "Execution error (ExceptionInfo) at user/eval")))))))

--- a/test/drawbridge/client_test.clj
+++ b/test/drawbridge/client_test.clj
@@ -39,14 +39,10 @@
                (send-message client {:op "eval" :code "(+ 1 2)"}))))
 
       (testing "Evaluating an invalid form returns an error"
-        (let [res (send-message client {:op "eval" :code "(+ 1 2"})]
-          (is (= (:status res) ["eval-error"]))
-          (is (= (:root-ex res) "class java.lang.RuntimeException"))
-          (is (some #{(:ex res)} #{"class clojure.lang.LispReader$ReaderException"
-                                   "class clojure.lang.ExceptionInfo"}))))
+        (is (= {:err "Syntax error reading source at (REPL:1:1).\nEOF while reading, starting at line 1\n"}
+               (send-message client {:op "eval" :code "(+ 1 2"}))))
 
       (testing "Evaluating a form that throws returns an error"
-        (is (= {:status  ["eval-error"]
-                :ex      "class clojure.lang.ExceptionInfo"
-                :root-ex "class clojure.lang.ExceptionInfo"}
-               (send-message client {:op "eval" :code "(throw (ex-info nil {:foo :bar}))"})))))))
+        (is (clojure.string/starts-with?
+              (:err (send-message client {:op "eval" :code "(throw (ex-info nil {:foo :bar}))"}))
+              "Execution error (ExceptionInfo) at user/eval"))))))


### PR DESCRIPTION
[nrepl "0.6.0"] changed the handling of evaluation errors.
To be compliant, this commit fixed the testcases.

An alternative would be to use the middleware introduces by
https://github.com/nrepl/nrepl/pull/128