### PR TITLE
Support Bearer authentication using env var `JWT`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -125,6 +125,18 @@ implementations to the `nrepl.core/url-connect` multimethod for
 tool that uses `url-connect` will use `ring-client-transport` for
 connecting to HTTP and HTTPS nREPL endpoints.
 
+==== Configuration
+
+The client supports additional HTTP headers, which is useful e.g. for
+using Bearer authorization to connect to the endpoint. The headers can
+be set in the nREPL configuration. For example, create `.nrepl.edn` in
+the working directory with the contents:
+
+[source,clojure]
+----
+{:drawbridge {:http-headers {:Authorization "Bearer <JWT token>"}}}
+----
+
 == TODO
 
 The biggest outstanding issues are around the semantics of how HTTP

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nrepl/drawbridge "0.2.0"
+(defproject nrepl/drawbridge "0.2.1"
   :description "HTTP transport support for Clojure's nREPL implemented as a Ring handler."
   :url "http://github.com/nrepl/drawbridge"
   :license {:name "Eclipse Public License"

--- a/src/drawbridge/client.clj
+++ b/src/drawbridge/client.clj
@@ -3,10 +3,13 @@
    [cheshire.core :as json]
    [clojure.java.io :as io]
    [clj-http.client :as http]
+   [nrepl.config]
    [nrepl.core :as nrepl]
    [nrepl.transport :as transport])
   (:import
    (java.util.concurrent LinkedBlockingQueue TimeUnit)))
+
+(def ^:private http-headers (get-in nrepl.config/config [:drawbridge :http-headers]))
 
 (defn ring-client-transport
   "Returns an nREPL client-side transport to connect to HTTP nREPL
@@ -33,7 +36,8 @@
                                                       url
                                                       (merge {:as :stream
                                                               :cookies @session-cookies}
-                                                             (when msg {:form-params msg})))]
+                                                             (when msg {:form-params msg})
+                                                             (when http-headers {:headers http-headers})))]
                  (swap! session-cookies merge cookies)
                  (fill body)))]
     (transport/->FnTransport


### PR DESCRIPTION
Hi!

We have JWT authentication in an application and I wanted to use drawbridge with it. Here's an implementation that gets the token from env var `JWT`. It works, but I'll concede that this may not be the most elegant way to do it. I'm open to suggestions.