### PR TITLE
Add polling throttle test and document timeout logic

### DIFF
--- a/test/drawbridge/client_test.clj
+++ b/test/drawbridge/client_test.clj
@@ -1,5 +1,6 @@
 (ns drawbridge.client-test
-  (:require [clojure.test :refer [deftest is use-fixtures testing]]
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is use-fixtures testing]]
             [compojure.core :refer [ANY defroutes]]
             [drawbridge.core :as drawbridge]
             [drawbridge.client]
@@ -31,58 +32,80 @@
 (defn- repl-url []
   (str "http://localhost:" *port* "/repl"))
 
-(defn without-unstable-keys
+(defmacro ^:private with-client
+  [[client-sym & {:keys [timeout] :or {timeout 1000}}] & body]
+  `(with-open [conn# (nrepl/url-connect (repl-url))]
+     (let [~client-sym (nrepl/client conn# ~timeout)]
+       ~@body)))
+
+(defn- without-unstable-keys
   [res]
   (map #(dissoc % :id :session) res))
 
-(defn send-message
+(defn- send-message
   [client message]
-  (-> client
-      (nrepl/message message)
+  (-> (nrepl/message client message)
       without-unstable-keys
       first))
 
-(deftest sending-messages
-  (with-open [conn (nrepl/url-connect (repl-url))]
-    (let [client (nrepl/client conn 1000)]
-      (testing "Evaluating a valid form returns the value"
-        (is (= {:value "3"
-                :ns    "user"}
-               (send-message client {:op "eval" :code "(+ 1 2)"}))))
+(deftest eval-messages
+  (with-client [client]
+    (testing "valid form returns value and namespace"
+      (is (= {:value "3" :ns "user"}
+             (send-message client {:op "eval" :code "(+ 1 2)"}))))
 
-      (testing "Evaluating an invalid form returns an error"
-        (is (re-find #"Syntax error reading source at \(REPL:\d+:\d+\)\.\nEOF while reading"
-                    (:err (send-message client {:op "eval" :code "(+ 1 2"})))))
+    (testing "invalid form returns reader error"
+      (is (re-find #"Syntax error reading source at \(REPL:\d+:\d+\)\.\nEOF while reading"
+                   (:err (send-message client {:op "eval" :code "(+ 1 2"})))))
 
-      (testing "Evaluating a form that throws returns an error"
-        (is (.startsWith
-              (:err (send-message client {:op "eval" :code "(throw (ex-info nil {:foo :bar}))"}))
-              "Execution error (ExceptionInfo) at user/eval"))))))
+    (testing "exception returns error"
+      (is (str/starts-with?
+           (:err (send-message client {:op "eval" :code "(throw (ex-info nil {:foo :bar}))"}))
+           "Execution error (ExceptionInfo) at user/eval")))
 
-(deftest sequential-evals-preserve-state
-  (with-open [conn (nrepl/url-connect (repl-url))]
-    (let [client (nrepl/client conn 1000)]
+    (testing "stdout is captured in :out key"
+      (let [messages (without-unstable-keys
+                      (nrepl/message client {:op "eval" :code "(println \"hello\")"}))]
+        (is (some #(= "hello\n" (:out %)) messages))))
+
+    (testing "sequential evals in the same session preserve state"
       (send-message client {:op "eval" :code "(def x 42)"})
       (is (= "42" (:value (send-message client {:op "eval" :code "x"})))))))
 
-(deftest stdout-output
-  (with-open [conn (nrepl/url-connect (repl-url))]
-    (let [client (nrepl/client conn 1000)
-          messages (without-unstable-keys
-                    (nrepl/message client {:op "eval" :code "(println \"hello\")"}))]
-      (is (some #(= "hello\n" (:out %)) messages)))))
+(deftest nrepl-ops
+  (with-client [client]
+    (testing "describe returns available ops"
+      (is (some? (:ops (send-message client {:op "describe"})))))))
 
-(deftest describe-op
-  (with-open [conn (nrepl/url-connect (repl-url))]
-    (let [client (nrepl/client conn 1000)
-          resp (send-message client {:op "describe"})]
-      (is (some? (:ops resp))))))
+(deftest transport-isolation
+  (testing "concurrent clients receive their own responses"
+    (with-open [conn-a (nrepl/url-connect (repl-url))
+                conn-b (nrepl/url-connect (repl-url))]
+      (let [client-a (nrepl/client conn-a 1000)
+            client-b (nrepl/client conn-b 1000)]
+        (is (= "3" (:value (send-message client-a {:op "eval" :code "(+ 1 2)"}))))
+        (is (= "30" (:value (send-message client-b {:op "eval" :code "(+ 10 20)"}))))))))
 
-(deftest concurrent-clients-get-own-responses
-  (with-open [conn-a (nrepl/url-connect (repl-url))
-              conn-b (nrepl/url-connect (repl-url))]
-    (let [client-a (nrepl/client conn-a 1000)
-          client-b (nrepl/client conn-b 1000)]
-      (is (= "3" (:value (send-message client-a {:op "eval" :code "(+ 1 2)"}))))
-      (is (= "30" (:value (send-message client-b {:op "eval" :code "(+ 10 20)"})))))))
-
+(deftest polling-is-throttled
+  (let [get-count (atom 0)
+        nrepl-handler (drawbridge/ring-handler)
+        counting-handler (-> (fn [request]
+                               (when (= :get (:request-method request))
+                                 (swap! get-count inc))
+                               (nrepl-handler request))
+                             wrap-keyword-params
+                             wrap-nested-params
+                             wrap-params)
+        server (jetty/run-jetty counting-handler {:port 0 :join? false})
+        port (.getLocalPort (first (.getConnectors server)))]
+    (try
+      (with-open [conn (nrepl/url-connect (str "http://localhost:" port "/repl"))]
+        (let [client (nrepl/client conn 500)]
+          ;; Eval a slow form so the client polls for the full timeout window.
+          ;; Server timeout is 0, so each GET returns [] immediately.
+          (doall (nrepl/message client {:op "eval" :code "(Thread/sleep 1000)"}))
+          ;; With 100ms throttle over ~500ms, expect roughly 5 GETs.
+          ;; Without throttle this would be 50+.
+          (is (< @get-count 15) "Polling should be throttled to avoid GET floods")))
+      (finally
+        (.stop server)))))


### PR DESCRIPTION
Followup to the GET flood fix (8663445). Adds a test that spins up a
server with a request counter and verifies GET polling stays bounded
(< 15 requests over a 500ms window). Also adds a comment to the read
function explaining the polling strategy and the 100ms backoff cap.

Fixes #10