### PR TITLE
Add an nREPL bridge, token auth, and a WebSocket transport

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,5 +1,19 @@
 = Changelog
 
+== master (unreleased)
+
+* Add `drawbridge.bridge`: a local nREPL socket server that relays to a
+  remote Drawbridge endpoint, so socket-based clients (CIDER, Calva,
+  rebel-readline, `nrepl.cmdline`) can connect to Drawbridge.
+* Add `drawbridge.auth/wrap-token` (constant-time bearer-token middleware)
+  and `drawbridge.core/secure-ring-handler`, a one-form secure endpoint
+  that refuses to run unauthenticated unless passed `:insecure true`.
+* https://github.com/nrepl/drawbridge/issues/44[#44]: Add a WebSocket
+  transport (`drawbridge.websocket` server side,
+  `drawbridge.websocket-client` client side, registered on `url-connect`
+  for `ws`/`wss`) with server push instead of HTTP long-polling.
+* Add an options arity to `ring-client-transport` accepting `:http-headers`.
+
 == 0.3.1 (2026-07-09)
 
 * Update dependencies: nREPL 1.7.0, Ring 1.15.5, Cheshire 6.2.0.

--- a/README.adoc
+++ b/README.adoc
@@ -86,43 +86,49 @@ Drawbridge has two sides:
 * A *client side* (`drawbridge.client`) that lets Clojure tooling connect
   to such an endpoint over HTTP/HTTPS.
 
-The sections below cover each in turn, with complete examples.
+There's also a *bridge* (`drawbridge.bridge`) that lets socket-based
+clients like CIDER and rebel-readline connect to a Drawbridge endpoint,
+and a *WebSocket transport* (`drawbridge.websocket`) that trades the
+HTTP long-polling for real-time server push. The sections below cover
+each in turn, with complete examples.
 
 == Server: exposing an nREPL endpoint over HTTP
 
-`drawbridge.core/ring-handler` returns an ordinary Ring handler. It needs
-the standard param middleware (`wrap-keyword-params`, `wrap-nested-params`
-and `wrap-params`, a.k.a. the Compojure "api" stack) applied to it, and it
-only responds to `GET` and `POST` requests. Session state is managed
-internally, so you don't need to add session middleware yourself.
+=== A secure endpoint in one form
 
-=== A standalone endpoint
-
-The smallest possible server: wrap the handler in the required middleware
-and run it with the Jetty adapter.
+`drawbridge.core/secure-ring-handler` returns a complete, ready-to-mount
+Ring handler: bearer-token authentication plus all the middleware the
+endpoint needs, correctly ordered.
 
 [source,clojure]
 ----
 (ns my-app.repl
   (:require
-   [drawbridge.core :refer [ring-handler]]
-   [ring.adapter.jetty :refer [run-jetty]]
-   [ring.middleware.keyword-params :refer [wrap-keyword-params]]
-   [ring.middleware.nested-params :refer [wrap-nested-params]]
-   [ring.middleware.params :refer [wrap-params]]))
-
-(def app
-  (-> (ring-handler)
-      wrap-keyword-params
-      wrap-nested-params
-      wrap-params))
+   [drawbridge.core :refer [secure-ring-handler]]
+   [ring.adapter.jetty :refer [run-jetty]]))
 
 (defn -main [& _]
-  (run-jetty app {:port 8080 :join? false}))
+  (run-jetty (secure-ring-handler :token (System/getenv "DRAWBRIDGE_TOKEN"))
+             {:port 8080 :join? false}))
 ----
 
-Run it and you have an nREPL endpoint at `http://localhost:8080/`. See
-the client section below for how to connect.
+Run it and you have a token-guarded nREPL endpoint at
+`http://localhost:8080/` -- see the client sections below for how to
+connect. Requests without a matching `Authorization: Bearer <token>`
+header get a 401.
+
+`secure-ring-handler` refuses to build an endpoint without a `:token`;
+if authentication is genuinely handled elsewhere in your stack, opt out
+explicitly with `:insecure true`.
+
+=== Assembling the handler yourself
+
+The underlying `drawbridge.core/ring-handler` returns an ordinary Ring
+handler. It needs the standard param middleware (`wrap-keyword-params`,
+`wrap-nested-params` and `wrap-params`, a.k.a. the Compojure "api"
+stack) applied to it, and it only responds to `GET` and `POST`
+requests. Session state is managed internally, so you don't need to add
+session middleware yourself.
 
 === Mounting into an existing app
 
@@ -154,7 +160,9 @@ https://github.com/weavejester/compojure[Compojure]:
 ----
 
 Any HTTP or HTTPS client can now send nREPL messages to `/repl` and read
-responses from the same URI.
+responses from the same URI. (The result of `secure-ring-handler` can be
+routed the same way -- it's just a Ring handler with the middleware
+already applied.)
 
 === Handler options
 
@@ -176,19 +184,25 @@ endpoint with authentication and authorization middleware before deploying to
 production. Use HTTPS to prevent credentials and REPL traffic from being
 transmitted in cleartext.
 
-Because the endpoint is just a Ring handler, any authentication or
-authorization middleware you already use applies. For example, gating it
-behind HTTP Basic auth:
+The built-in answer is bearer-token auth: use `secure-ring-handler`
+(shown above), or apply `drawbridge.auth/wrap-token` directly when
+assembling the handler yourself. The token comparison is
+constant-time, and the client side sends the matching header via
+`.nrepl.edn`, the bridge's `--token` argument, or the transports'
+`:http-headers` option.
 
 [source,clojure]
 ----
-(require '[ring.middleware.basic-authentication :refer [wrap-basic-authentication]])
+(require '[drawbridge.auth :refer [wrap-token]])
 
 (def secured-drawbridge
-  (-> drawbridge
-      (wrap-basic-authentication
-       (fn [user pass] (and (= user "me") (= pass "secret"))))))
+  (wrap-token drawbridge (System/getenv "DRAWBRIDGE_TOKEN")))
 ----
+
+Because the endpoint is just a Ring handler, any other authentication or
+authorization middleware you already use applies too -- e.g. HTTP Basic
+auth via `ring.middleware.basic-authentication`, or whatever guards the
+rest of your app.
 
 == Client: connecting to an endpoint
 
@@ -273,16 +287,91 @@ configuration by creating `.nrepl.edn` in the working directory:
 
 These headers are attached to every request the client makes.
 
-=== A note on socket-based clients
+== Editors and terminal REPLs: the bridge
 
 Many nREPL clients -- editor tooling such as CIDER, Calva, and Conjure,
-terminal REPLs like rebel-readline, and nREPL's own `--connect` command line
--- connect using a host and port over a raw socket rather than a URL. These
-never go through `url-connect`, so they cannot talk to a Drawbridge endpoint
-directly. Drawbridge targets URL-based connections (`lein repl :connect`, the
-Clojure CLI example above) and programmatic clients. To reach an endpoint
-from a socket-based client you'd need an nREPL client that speaks the HTTP
-transport, or a local process that bridges a socket to the HTTP endpoint.
+terminal REPLs like rebel-readline, and nREPL's own `--connect` command
+line -- connect using a host and port over a raw socket rather than a
+URL. These never go through `url-connect`, so they cannot talk to a
+Drawbridge endpoint directly.
+
+The bridge closes that gap. It's a small local process that listens on
+a plain nREPL socket and relays every message to a remote Drawbridge
+endpoint:
+
+[source,shell]
+----
+clojure -Sdeps '{:deps {nrepl/drawbridge {:mvn/version "0.3.1"}}}' \
+  -M -m drawbridge.bridge --url https://my-app.example.com/repl \
+  --port 7888 --token $DRAWBRIDGE_TOKEN
+----
+
+Now `cider-connect` to `localhost:7888` (or point Calva, rebel-readline,
+or any other nREPL client there) and you're evaluating code on the
+remote app. Each local connection gets its own session on the remote
+end, and `--token` is sent as an `Authorization: Bearer` header --
+pairing with `secure-ring-handler` on the server.
+
+The bridge can also be started programmatically with
+`drawbridge.bridge/start-bridge`. When given a `ws://` or `wss://` URL
+it speaks the WebSocket transport (see below) instead of HTTP
+long-polling, which eliminates polling latency entirely.
+
+== WebSocket transport
+
+The HTTP transport works everywhere, but it's polling-based: the client
+has to keep asking the server for output. The WebSocket transport lets
+the server push nREPL responses the moment they're produced -- snappier
+evals, streaming output, no polling traffic.
+
+On the server, `drawbridge.websocket/ring-handler` returns a Ring
+handler that upgrades WebSocket requests and speaks nREPL over JSON
+text frames. It needs no param middleware, and plain HTTP requests can
+fall through to the long-poll handler so a single route serves both
+transports:
+
+[source,clojure]
+----
+(ns my-app.repl
+  (:require
+   [drawbridge.auth :refer [wrap-token]]
+   [drawbridge.core :as drawbridge]
+   [drawbridge.websocket :as websocket]
+   [ring.adapter.jetty :refer [run-jetty]]))
+
+(def app
+  (-> (websocket/ring-handler
+       :fallback (drawbridge/secure-ring-handler :insecure true))
+      (wrap-token (System/getenv "DRAWBRIDGE_TOKEN"))))
+
+(defn -main [& _]
+  (run-jetty app {:port 8080 :join? false}))
+----
+
+(Note how `wrap-token` guards both transports at once, so the fallback
+handler opts out of its own auth with `:insecure true`.)
+
+WebSocket support requires a Ring adapter that implements the Ring 1.11+
+WebSocket API -- ring-jetty-adapter does out of the box.
+
+On the client, `drawbridge.websocket-client` registers the `ws` and
+`wss` schemes with `url-connect` (using the JDK's built-in WebSocket
+client, no extra dependencies):
+
+[source,clojure]
+----
+(require '[drawbridge.websocket-client] ;; registers ws/wss on url-connect
+         '[nrepl.core :as nrepl])
+
+(with-open [conn (nrepl/url-connect "ws://localhost:8080/")]
+  (-> (nrepl/client conn 1000)
+      (nrepl/message {:op "eval" :code "(+ 1 2)"})
+      nrepl/response-values))
+;; => [3]
+----
+
+...and, as noted above, the bridge picks this transport automatically
+for `ws(s)://` URLs -- the recommended setup for editor use.
 
 == Need Help?
 

--- a/src/drawbridge/auth.clj
+++ b/src/drawbridge/auth.clj
@@ -1,0 +1,43 @@
+(ns drawbridge.auth
+  "Authentication middleware for Drawbridge endpoints.
+
+  A Drawbridge endpoint is remote code execution by design, so it
+  should never be exposed without authentication. `wrap-token`
+  provides a minimal, dependency-free bearer-token scheme that pairs
+  with the client side's HTTP header support (`.nrepl.edn`'s
+  [:drawbridge :http-headers], the bridge's `--token` argument, or
+  `ring-client-transport`'s :http-headers option)."
+  (:require [cheshire.core :as json])
+  (:import (java.nio.charset StandardCharsets)
+           (java.security MessageDigest)))
+
+(def ^:private unauthorized-response
+  {:status 401
+   :headers {"Content-Type" "application/json"
+             "WWW-Authenticate" "Bearer"}
+   :body (json/generate-string {:error "Unauthorized"
+                                :reason "This nREPL endpoint requires a valid bearer token."})})
+
+(defn- constant-time=
+  "Compare two strings in constant time, so response timing doesn't
+  leak how much of a guessed token matched."
+  [^String a ^String b]
+  (MessageDigest/isEqual (.getBytes a StandardCharsets/UTF_8)
+                         (.getBytes b StandardCharsets/UTF_8)))
+
+(defn- bearer-token
+  [request]
+  (when-let [auth (get-in request [:headers "authorization"])]
+    (second (re-matches #"(?i)bearer (.+)" auth))))
+
+(defn wrap-token
+  "Middleware that rejects any request not carrying an
+  `Authorization: Bearer <token>` header matching `token`, responding
+  with a JSON 401. Apply it outside the param middlewares so
+  unauthenticated requests are rejected before any parsing."
+  [handler token]
+  {:pre [(seq token)]}
+  (fn [request]
+    (if (some-> (bearer-token request) (constant-time= token))
+      (handler request)
+      unauthorized-response)))

--- a/src/drawbridge/bridge.clj
+++ b/src/drawbridge/bridge.clj
@@ -22,24 +22,40 @@
   speaks the WebSocket transport (`drawbridge.websocket-client`)
   instead, and responses are pushed with no polling delay."
   (:require
+   [clojure.walk :as walk]
    [drawbridge.client :as client]
    [drawbridge.websocket-client :as ws-client]
    [nrepl.transport :as transport])
   (:import
+   (java.io Closeable)
    (java.net InetAddress ServerSocket Socket)))
 
-(def ^:private poll-timeout
-  "Milliseconds to wait per `recv` poll in the relay loops. For the
-  remote (HTTP) side this bounds how often an idle connection polls
-  the endpoint; for the local side it merely bounds how often the
-  loop rechecks that the connection is still open."
-  100)
+(def ^:private default-poll-opts
+  "Pacing for the remote->local relay loop. While the connection is
+  active we poll eagerly (`:active-poll-ms` per recv); once no message
+  has moved in either direction for `:idle-after-ms` we sleep
+  `:idle-poll-ms` between polls, so an editor left connected overnight
+  doesn't hammer the remote HTTP endpoint. Only spontaneous async
+  output is delayed while idle -- any client message snaps the
+  connection back to eager polling."
+  {:active-poll-ms 100
+   :idle-poll-ms 2000
+   :idle-after-ms 30000})
 
-(defn- strip-nils
-  "Remove nil-valued entries from a message. JSON `null`s in HTTP
-  responses decode to nil, but bencode cannot encode nil."
+(defn- bencode-safe
+  "Make a relayed message encodable as bencode, at any nesting depth:
+  drop nil-valued map entries (JSON `null`s; bencode renders nil as a
+  confusing empty list) and render booleans and non-integer numbers --
+  which bencode cannot carry at all -- as strings."
   [msg]
-  (into {} (remove (comp nil? val)) msg))
+  (walk/postwalk
+   (fn [x]
+     (cond
+       (map? x) (into {} (remove (comp nil? val)) x)
+       (boolean? x) (str x)
+       (and (number? x) (not (integer? x))) (str x)
+       :else x))
+   msg))
 
 (defn- remote-transport
   "Open a client transport for `url`, picking the WebSocket transport
@@ -53,28 +69,45 @@
   "Relay messages between a local socket and the remote Drawbridge
   endpoint at `url` until either side disconnects. Calls `on-close`
   once when the connection winds down."
-  [^Socket sock url http-headers on-close]
+  [^Socket sock url http-headers poll-opts on-close]
   (let [local (transport/bencode sock)
         remote (remote-transport url http-headers)
+        {:keys [active-poll-ms idle-poll-ms idle-after-ms]} poll-opts
         open? (atom true)
+        last-activity (atom (System/currentTimeMillis))
         close! (fn []
                  (when (compare-and-set! open? true false)
                    (.close sock)
+                   ;; The remote side holds real resources (an HTTP
+                   ;; session, or a live WebSocket) -- release them.
+                   (try
+                     (.close ^Closeable remote)
+                     (catch Exception _))
                    (on-close)))]
-    ;; remote -> local: poll the HTTP endpoint, push responses back.
+    ;; remote -> local: fetch responses, push them to the client.
+    ;; Poll eagerly while active, back off once idle (see
+    ;; default-poll-opts). A dead remote surfaces as an exception
+    ;; from recv (HTTP: the request throws; WS: recv throws once the
+    ;; socket is closed), tearing the relay down.
     (future
       (try
         (while @open?
-          (when-let [msg (transport/recv remote poll-timeout)]
-            (transport/send local (strip-nils msg))))
+          (if-let [msg (transport/recv remote active-poll-ms)]
+            (do (reset! last-activity (System/currentTimeMillis))
+                (transport/send local (bencode-safe msg)))
+            (when (> (- (System/currentTimeMillis) @last-activity) idle-after-ms)
+              (Thread/sleep ^long idle-poll-ms))))
         (catch Exception _)
         (finally (close!))))
-    ;; local -> remote: forward every client message as an HTTP POST.
-    ;; A disconnected client surfaces as a SocketException from recv.
+    ;; local -> remote: forward every client message. recv blocks
+    ;; until a message arrives and throws once the socket is closed
+    ;; (by the client, by stop-bridge, or by close! from the other
+    ;; loop), which tears the relay down via close!.
     (future
       (try
         (while @open?
-          (when-let [msg (transport/recv local poll-timeout)]
+          (when-let [msg (transport/recv local)]
+            (reset! last-activity (System/currentTimeMillis))
             (transport/send remote msg)))
         (catch Exception _)
         (finally (close!))))))
@@ -91,20 +124,24 @@
   * `:bind` -- local address to bind (default \"127.0.0.1\")
   * `:http-headers` -- extra HTTP headers to send with every request,
     e.g. {\"Authorization\" \"Bearer <token>\"}
+  * `:active-poll-ms`, `:idle-poll-ms`, `:idle-after-ms` -- pacing of
+    the remote polling loop (see `default-poll-opts`)
 
   Returns a map with `:port` (the bound local port) and `:server`;
   pass it to `stop-bridge` to shut down."
-  [{:keys [url port bind http-headers] :or {port 0 bind "127.0.0.1"}}]
+  [{:keys [url port bind http-headers] :or {port 0 bind "127.0.0.1"} :as opts}]
   (when-not url
     (throw (IllegalArgumentException. "A remote Drawbridge :url is required")))
   (let [server (ServerSocket. port 50 (InetAddress/getByName bind))
+        poll-opts (merge default-poll-opts
+                         (select-keys opts [:active-poll-ms :idle-poll-ms :idle-after-ms]))
         connections (atom #{})]
     (future
       (try
         (loop []
           (let [^Socket sock (.accept server)]
             (swap! connections conj sock)
-            (relay sock url http-headers
+            (relay sock url http-headers poll-opts
                    #(swap! connections disj sock))
             (recur)))
         ;; Closing the server socket unblocks accept with an exception.
@@ -121,6 +158,18 @@
   (doseq [^Socket sock @connections]
     (.close sock)))
 
+(defn- parse-args
+  "Parse -main's `--key value` argument pairs into start-bridge
+  options. :url is nil when missing."
+  [args]
+  (let [opts (apply hash-map args)
+        token (get opts "--token")]
+    (cond-> {:url (get opts "--url")
+             :port (or (some-> (get opts "--port") Long/parseLong) 7888)
+             :bind (get opts "--bind" "127.0.0.1")}
+      token (assoc :http-headers
+                   {"Authorization" (str "Bearer " token)}))))
+
 (defn -main
   "Command-line entry point.
 
@@ -131,19 +180,12 @@
   * `--bind ADDR` -- local address to bind (default 127.0.0.1)
   * `--token TOKEN` -- sent as an `Authorization: Bearer` header"
   [& args]
-  (let [opts (apply hash-map args)
-        url (get opts "--url")
-        port (or (some-> (get opts "--port") Long/parseLong) 7888)
-        bind (get opts "--bind" "127.0.0.1")
-        token (get opts "--token")]
+  (let [{:keys [url bind] :as opts} (parse-args args)]
     (when-not url
       (binding [*out* *err*]
         (println "Usage: -m drawbridge.bridge --url URL [--port N] [--bind ADDR] [--token TOKEN]"))
       (System/exit 1))
-    (let [bridge (start-bridge
-                  (cond-> {:url url :port port :bind bind}
-                    token (assoc :http-headers
-                                 {"Authorization" (str "Bearer " token)})))]
+    (let [bridge (start-bridge opts)]
       (println (format "Drawbridge bridge: nREPL on %s:%d -> %s"
                        bind (:port bridge) url))
       (println "Point your nREPL client (CIDER, Calva, rebel-readline, ...) at this port.")

--- a/src/drawbridge/bridge.clj
+++ b/src/drawbridge/bridge.clj
@@ -1,0 +1,139 @@
+(ns drawbridge.bridge
+  "A local nREPL bridge for Drawbridge HTTP endpoints.
+
+  Most nREPL clients (CIDER, Calva, Conjure, rebel-readline, nREPL's
+  own command line) speak bencode over a plain socket and cannot talk
+  to a Drawbridge HTTP endpoint directly. This namespace runs a small
+  local socket server that accepts those connections and relays every
+  message to a remote Drawbridge endpoint over HTTP(S), pushing the
+  responses back. Each local connection gets its own HTTP session on
+  the remote end, so concurrent clients stay isolated.
+
+  Command-line usage:
+
+      clojure -M -m drawbridge.bridge --url https://my-app.example.com/repl \\
+              --port 7888 --token $DRAWBRIDGE_TOKEN
+
+  ...then point any nREPL client at localhost:7888.
+
+  Note that responses are fetched by polling the HTTP endpoint (see
+  `drawbridge.client` for the throttling details), so output arrives
+  with up to ~100ms of latency."
+  (:require
+   [drawbridge.client :as client]
+   [nrepl.transport :as transport])
+  (:import
+   (java.net InetAddress ServerSocket Socket)))
+
+(def ^:private poll-timeout
+  "Milliseconds to wait per `recv` poll in the relay loops. For the
+  remote (HTTP) side this bounds how often an idle connection polls
+  the endpoint; for the local side it merely bounds how often the
+  loop rechecks that the connection is still open."
+  100)
+
+(defn- strip-nils
+  "Remove nil-valued entries from a message. JSON `null`s in HTTP
+  responses decode to nil, but bencode cannot encode nil."
+  [msg]
+  (into {} (remove (comp nil? val)) msg))
+
+(defn- relay
+  "Relay messages between a local socket and the remote Drawbridge
+  endpoint at `url` until either side disconnects. Calls `on-close`
+  once when the connection winds down."
+  [^Socket sock url http-headers on-close]
+  (let [local (transport/bencode sock)
+        remote (client/ring-client-transport url {:http-headers http-headers})
+        open? (atom true)
+        close! (fn []
+                 (when (compare-and-set! open? true false)
+                   (.close sock)
+                   (on-close)))]
+    ;; remote -> local: poll the HTTP endpoint, push responses back.
+    (future
+      (try
+        (while @open?
+          (when-let [msg (transport/recv remote poll-timeout)]
+            (transport/send local (strip-nils msg))))
+        (catch Exception _)
+        (finally (close!))))
+    ;; local -> remote: forward every client message as an HTTP POST.
+    ;; A disconnected client surfaces as a SocketException from recv.
+    (future
+      (try
+        (while @open?
+          (when-let [msg (transport/recv local poll-timeout)]
+            (transport/send remote msg)))
+        (catch Exception _)
+        (finally (close!))))))
+
+(defn start-bridge
+  "Start a local nREPL socket server that bridges to the Drawbridge
+  endpoint at `:url`.
+
+  Options:
+
+  * `:url` (required) -- the remote Drawbridge endpoint,
+    e.g. \"https://my-app.example.com/repl\"
+  * `:port` -- local port to listen on (default 0, i.e. a free port)
+  * `:bind` -- local address to bind (default \"127.0.0.1\")
+  * `:http-headers` -- extra HTTP headers to send with every request,
+    e.g. {\"Authorization\" \"Bearer <token>\"}
+
+  Returns a map with `:port` (the bound local port) and `:server`;
+  pass it to `stop-bridge` to shut down."
+  [{:keys [url port bind http-headers] :or {port 0 bind "127.0.0.1"}}]
+  (when-not url
+    (throw (IllegalArgumentException. "A remote Drawbridge :url is required")))
+  (let [server (ServerSocket. port 50 (InetAddress/getByName bind))
+        connections (atom #{})]
+    (future
+      (try
+        (loop []
+          (let [^Socket sock (.accept server)]
+            (swap! connections conj sock)
+            (relay sock url http-headers
+                   #(swap! connections disj sock))
+            (recur)))
+        ;; Closing the server socket unblocks accept with an exception.
+        (catch Exception _)))
+    {:server server
+     :connections connections
+     :port (.getLocalPort server)}))
+
+(defn stop-bridge
+  "Stop a bridge started with `start-bridge`, closing the listening
+  socket and any open connections."
+  [{:keys [^ServerSocket server connections]}]
+  (.close server)
+  (doseq [^Socket sock @connections]
+    (.close sock)))
+
+(defn -main
+  "Command-line entry point.
+
+  Arguments (as `--key value` pairs):
+
+  * `--url URL` (required) -- the remote Drawbridge endpoint
+  * `--port N` -- local port to listen on (default 7888)
+  * `--bind ADDR` -- local address to bind (default 127.0.0.1)
+  * `--token TOKEN` -- sent as an `Authorization: Bearer` header"
+  [& args]
+  (let [opts (apply hash-map args)
+        url (get opts "--url")
+        port (or (some-> (get opts "--port") Long/parseLong) 7888)
+        bind (get opts "--bind" "127.0.0.1")
+        token (get opts "--token")]
+    (when-not url
+      (binding [*out* *err*]
+        (println "Usage: -m drawbridge.bridge --url URL [--port N] [--bind ADDR] [--token TOKEN]"))
+      (System/exit 1))
+    (let [bridge (start-bridge
+                  (cond-> {:url url :port port :bind bind}
+                    token (assoc :http-headers
+                                 {"Authorization" (str "Bearer " token)})))]
+      (println (format "Drawbridge bridge: nREPL on %s:%d -> %s"
+                       bind (:port bridge) url))
+      (println "Point your nREPL client (CIDER, Calva, rebel-readline, ...) at this port.")
+      @(promise))))

--- a/src/drawbridge/bridge.clj
+++ b/src/drawbridge/bridge.clj
@@ -16,11 +16,14 @@
 
   ...then point any nREPL client at localhost:7888.
 
-  Note that responses are fetched by polling the HTTP endpoint (see
-  `drawbridge.client` for the throttling details), so output arrives
-  with up to ~100ms of latency."
+  For http(s) URLs, responses are fetched by polling the endpoint
+  (see `drawbridge.client` for the throttling details), so output
+  arrives with up to ~100ms of latency. For ws(s) URLs the bridge
+  speaks the WebSocket transport (`drawbridge.websocket-client`)
+  instead, and responses are pushed with no polling delay."
   (:require
    [drawbridge.client :as client]
+   [drawbridge.websocket-client :as ws-client]
    [nrepl.transport :as transport])
   (:import
    (java.net InetAddress ServerSocket Socket)))
@@ -38,13 +41,21 @@
   [msg]
   (into {} (remove (comp nil? val)) msg))
 
+(defn- remote-transport
+  "Open a client transport for `url`, picking the WebSocket transport
+  for ws/wss URLs and HTTP long-polling otherwise."
+  [url http-headers]
+  (if (re-find #"(?i)^wss?://" url)
+    (ws-client/websocket-client-transport url {:http-headers http-headers})
+    (client/ring-client-transport url {:http-headers http-headers})))
+
 (defn- relay
   "Relay messages between a local socket and the remote Drawbridge
   endpoint at `url` until either side disconnects. Calls `on-close`
   once when the connection winds down."
   [^Socket sock url http-headers on-close]
   (let [local (transport/bencode sock)
-        remote (client/ring-client-transport url {:http-headers http-headers})
+        remote (remote-transport url http-headers)
         open? (atom true)
         close! (fn []
                  (when (compare-and-set! open? true false)

--- a/src/drawbridge/client.clj
+++ b/src/drawbridge/client.clj
@@ -9,56 +9,65 @@
   (:import
    (java.util.concurrent LinkedBlockingQueue TimeUnit)))
 
-(def ^:private http-headers (get-in nrepl.config/config [:drawbridge :http-headers]))
+(def ^:private default-http-headers
+  (get-in nrepl.config/config [:drawbridge :http-headers]))
 
 (defn ring-client-transport
   "Returns an nREPL client-side transport to connect to HTTP nREPL
    endpoints implemented by `ring-handler`.
+
+   Accepts an options map with the following keys:
+
+   * `:http-headers` -- extra HTTP headers to send with every request,
+     e.g. {\"Authorization\" \"Bearer <token>\"}. Defaults to the
+     `[:drawbridge :http-headers]` entry of the nREPL config
+     (see `.nrepl.edn`).
 
    This fn is implicitly registered as the implementation of
    `nrepl.core/url-connect` for `http` and `https` schemes;
    so, once this namespace is loaded, any tool that uses `url-connect`
    will use this implementation for connecting to HTTP and HTTPS
    nREPL endpoints."
-  [url]
-  (let [incoming (LinkedBlockingQueue.)
-        fill (fn [body]
-               (when-let [responses (->> (io/reader body)
-                                         line-seq
-                                         rest
-                                         drop-last
-                                         (map #(json/parse-string % true))
-                                         (remove nil?)
-                                         seq)]
-                 (.addAll incoming responses)))
-        session-cookies (atom nil)
-        http (fn [& [msg]]
-               (let [{:keys [cookies body] :as resp} ((if msg http/post http/get)
-                                                      url
-                                                      (merge {:as :stream
-                                                              :cookies @session-cookies}
-                                                             (when msg {:form-params msg})
-                                                             (when http-headers {:headers http-headers})))]
-                 (swap! session-cookies merge cookies)
-                 (fill body)))]
-    (transport/->FnTransport
-     ;; Read the next response message, polling the server via HTTP.
-     ;; First checks the local queue without blocking. If empty and time
-     ;; remains, fires an HTTP GET (which may fill the queue via `fill`),
-     ;; then waits up to 100ms for a result before retrying. The 100ms
-     ;; cap avoids flooding the server with GETs when no responses are
-     ;; pending (see #10).
-     (fn read [timeout]
-       (let [t (System/currentTimeMillis)]
-         (or (.poll incoming 0 TimeUnit/MILLISECONDS)
-             (when (pos? timeout)
-               (http)
-               (or (.poll incoming (min timeout 100) TimeUnit/MILLISECONDS)
-                   (let [remaining (- timeout (- (System/currentTimeMillis) t))]
-                     (when (pos? remaining)
-                       (recur remaining))))))))
-     http
-     (fn close []))))
+  ([url] (ring-client-transport url nil))
+  ([url {:keys [http-headers] :or {http-headers default-http-headers}}]
+   (let [incoming (LinkedBlockingQueue.)
+         fill (fn [body]
+                (when-let [responses (->> (io/reader body)
+                                          line-seq
+                                          rest
+                                          drop-last
+                                          (map #(json/parse-string % true))
+                                          (remove nil?)
+                                          seq)]
+                  (.addAll incoming responses)))
+         session-cookies (atom nil)
+         http (fn [& [msg]]
+                (let [{:keys [cookies body] :as resp} ((if msg http/post http/get)
+                                                       url
+                                                       (merge {:as :stream
+                                                               :cookies @session-cookies}
+                                                              (when msg {:form-params msg})
+                                                              (when http-headers {:headers http-headers})))]
+                  (swap! session-cookies merge cookies)
+                  (fill body)))]
+     (transport/->FnTransport
+      ;; Read the next response message, polling the server via HTTP.
+      ;; First checks the local queue without blocking. If empty and time
+      ;; remains, fires an HTTP GET (which may fill the queue via `fill`),
+      ;; then waits up to 100ms for a result before retrying. The 100ms
+      ;; cap avoids flooding the server with GETs when no responses are
+      ;; pending (see #10).
+      (fn read [timeout]
+        (let [t (System/currentTimeMillis)]
+          (or (.poll incoming 0 TimeUnit/MILLISECONDS)
+              (when (pos? timeout)
+                (http)
+                (or (.poll incoming (min timeout 100) TimeUnit/MILLISECONDS)
+                    (let [remaining (- timeout (- (System/currentTimeMillis) t))]
+                      (when (pos? remaining)
+                        (recur remaining))))))))
+      http
+      (fn close [])))))
 
 (.addMethod nrepl/url-connect "http" #'ring-client-transport)
 (.addMethod nrepl/url-connect "https" #'ring-client-transport)

--- a/src/drawbridge/client.clj
+++ b/src/drawbridge/client.clj
@@ -57,6 +57,13 @@
                                                               (when http-headers {:headers http-headers})))]
                   (swap! session-cookies merge cookies)
                   (fill body)))]
+     ;; Establish the server-side session before returning: every
+     ;; cookie-less request creates a fresh session, so concurrent
+     ;; GET/POST from separate threads (a REPL's reader and writer,
+     ;; the bridge's polling loop) could otherwise end up bound to
+     ;; different sessions and responses would never be delivered.
+     ;; This also surfaces connection/auth errors at connect time.
+     (http)
      (transport/->FnTransport
       ;; Read the next response message, polling the server via HTTP.
       ;; First checks the local queue without blocking. If empty and time

--- a/src/drawbridge/client.clj
+++ b/src/drawbridge/client.clj
@@ -9,7 +9,10 @@
   (:import
    (java.util.concurrent LinkedBlockingQueue TimeUnit)))
 
-(def ^:private default-http-headers
+(def default-http-headers
+  "Extra HTTP headers configured under [:drawbridge :http-headers] in
+   the nREPL config (e.g. `.nrepl.edn`). All Drawbridge client
+   transports send these when no :http-headers option is given."
   (get-in nrepl.config/config [:drawbridge :http-headers]))
 
 (defn ring-client-transport
@@ -19,9 +22,9 @@
    Accepts an options map with the following keys:
 
    * `:http-headers` -- extra HTTP headers to send with every request,
-     e.g. {\"Authorization\" \"Bearer <token>\"}. Defaults to the
-     `[:drawbridge :http-headers]` entry of the nREPL config
-     (see `.nrepl.edn`).
+     e.g. {\"Authorization\" \"Bearer <token>\"}. When nil or absent,
+     falls back to `default-http-headers` (the nREPL config); pass an
+     empty map to send no extra headers despite the config.
 
    This fn is implicitly registered as the implementation of
    `nrepl.core/url-connect` for `http` and `https` schemes;
@@ -29,8 +32,12 @@
    will use this implementation for connecting to HTTP and HTTPS
    nREPL endpoints."
   ([url] (ring-client-transport url nil))
-  ([url {:keys [http-headers] :or {http-headers default-http-headers}}]
-   (let [incoming (LinkedBlockingQueue.)
+  ([url {:keys [http-headers]}]
+   ;; `or`, not destructuring :or -- callers passing an explicit nil
+   ;; (e.g. the bridge without --token) must still get the config
+   ;; default, and :or only fires when the key is absent.
+   (let [http-headers (or http-headers default-http-headers)
+         incoming (LinkedBlockingQueue.)
          fill (fn [body]
                 (when-let [responses (->> (io/reader body)
                                           line-seq

--- a/src/drawbridge/core.clj
+++ b/src/drawbridge/core.clj
@@ -12,6 +12,7 @@
   (:require
    [cheshire.core :as json]
    clojure.walk
+   [drawbridge.auth :as auth]
    [nrepl.core :as nrepl]
    [nrepl.server :as server]
    [nrepl.transport :as transport]
@@ -124,6 +125,32 @@
                             (future (server/handle* msg nrepl-handler write)))
                           (client)))))))
       (memory-session :cookie-name cookie-name)))
+
+(defn secure-ring-handler
+  "Like `ring-handler`, but returns a complete, ready-to-mount Ring
+   handler: the required param middlewares are applied in the right
+   order and the endpoint is protected by bearer-token authentication
+   (see `drawbridge.auth/wrap-token`).
+
+   Accepts all of `ring-handler`'s options plus:
+
+     * :token -- the bearer token clients must present on every request.
+     * :insecure -- pass true to deliberately opt out of authentication,
+       e.g. when auth is enforced elsewhere in your middleware stack.
+
+   Exposing an unauthenticated nREPL endpoint means anyone who can
+   reach it can execute arbitrary code, so omitting :token without
+   explicitly passing :insecure true throws."
+  [& {:keys [token insecure] :as opts}]
+  (when-not (or (seq token) (true? insecure))
+    (throw (IllegalArgumentException.
+            (str "Refusing to create an unauthenticated nREPL endpoint. "
+                 "Pass a :token, or :insecure true to opt out of authentication."))))
+  (cond-> (-> (apply ring-handler (mapcat identity (dissoc opts :token :insecure)))
+              wrap-keyword-params
+              wrap-nested-params
+              wrap-params)
+    (seq token) (auth/wrap-token token)))
 
 ;; enable easy interactive debugging of typical usage
 (def ^{:private true} app (-> (ring-handler)

--- a/src/drawbridge/websocket.clj
+++ b/src/drawbridge/websocket.clj
@@ -31,18 +31,20 @@
 (defn- websocket-transport
   "An nREPL transport that pushes response messages to the client as
   JSON text frames. The server never reads from a transport (messages
-  arrive via `on-message`), so `recv` always returns nil."
+  arrive via `on-message`), so `recv` always returns nil.
+
+  Must be created once per connection: the lock serializes all
+  writers on the shared socket (nREPL serializes sends per session,
+  not per connection, so two sessions on one connection would
+  otherwise write frames concurrently)."
   [socket]
   (let [lock (Object.)]
-    (reify transport/Transport
-      (send [this msg]
-        ;; ws/send is not guaranteed to be safe under concurrent
-        ;; writers (e.g. an eval's stdout racing its :done message).
-        (locking lock
-          (ws/send socket (json/generate-string msg)))
-        this)
-      (recv [_this] nil)
-      (recv [_this _timeout] nil))))
+    (transport/->FnTransport
+     (constantly nil)
+     (fn [msg]
+       (locking lock
+         (ws/send socket (json/generate-string msg))))
+     (fn []))))
 
 (defn ring-handler
   "Returns a Ring handler implementing a WebSocket transport endpoint
@@ -70,14 +72,18 @@
            fallback (constantly upgrade-required-response)}}]
   (fn [request]
     (if (ws/upgrade-request? request)
-      {::ws/listener
-       {:on-open (fn [_socket])
-        :on-message (fn [socket message]
-                      (let [msg (json/parse-string (str message) true)
-                            transport (websocket-transport socket)]
-                        (future (server/handle* msg nrepl-handler transport))))
-        :on-error (fn [socket _throwable]
-                    (when (ws/open? socket)
-                      (ws/close socket 1011 "nREPL transport error")))
-        :on-close (fn [_socket _code _reason])}}
+      ;; One transport per connection, so its lock serializes every
+      ;; writer targeting this socket across all in-flight messages.
+      (let [transport (volatile! nil)]
+        {::ws/listener
+         {:on-open (fn [socket]
+                     (vreset! transport (websocket-transport socket)))
+          :on-message (fn [_socket message]
+                        (let [msg (json/parse-string (str message) true)
+                              t @transport]
+                          (future (server/handle* msg nrepl-handler t))))
+          :on-error (fn [socket _throwable]
+                      (when (ws/open? socket)
+                        (ws/close socket 1011 "nREPL transport error")))
+          :on-close (fn [_socket _code _reason])}})
       (fallback request))))

--- a/src/drawbridge/websocket.clj
+++ b/src/drawbridge/websocket.clj
@@ -1,0 +1,83 @@
+(ns drawbridge.websocket
+  "WebSocket transport support for nREPL, server side.
+
+  Unlike the HTTP long-poll transport in `drawbridge.core`, a
+  WebSocket connection lets the server push nREPL responses as they
+  are produced -- no polling, no per-request session cookies, and a
+  connection maps naturally onto a stateful nREPL client. Prefer this
+  transport when your deployment environment allows WebSocket
+  upgrades; keep the HTTP transport as a fallback for environments
+  that don't.
+
+  Messages are JSON-encoded text frames in both directions, one nREPL
+  message per frame.
+
+  See `drawbridge.websocket-client` for the matching client-side
+  transport."
+  (:require
+   [cheshire.core :as json]
+   [nrepl.server :as server]
+   [nrepl.transport :as transport]
+   [ring.websocket :as ws]))
+
+(def ^:private upgrade-required-response
+  {:status 426
+   :headers {"Content-Type" "application/json"
+             "Upgrade" "websocket"}
+   :body (json/generate-string
+          {:error "Upgrade Required"
+           :reason "This nREPL endpoint speaks WebSocket; send an upgrade request."})})
+
+(defn- websocket-transport
+  "An nREPL transport that pushes response messages to the client as
+  JSON text frames. The server never reads from a transport (messages
+  arrive via `on-message`), so `recv` always returns nil."
+  [socket]
+  (let [lock (Object.)]
+    (reify transport/Transport
+      (send [this msg]
+        ;; ws/send is not guaranteed to be safe under concurrent
+        ;; writers (e.g. an eval's stdout racing its :done message).
+        (locking lock
+          (ws/send socket (json/generate-string msg)))
+        this)
+      (recv [_this] nil)
+      (recv [_this _timeout] nil))))
+
+(defn ring-handler
+  "Returns a Ring handler implementing a WebSocket transport endpoint
+   for nREPL. Requires a Ring adapter with WebSocket support (e.g.
+   ring-jetty-adapter 1.11+).
+
+   Each WebSocket connection gets its own transport; incoming text
+   frames are JSON-decoded and dispatched to the nREPL handler, and
+   every response is pushed back as a JSON text frame as soon as it
+   is produced.
+
+   Options:
+
+     * :nrepl-handler -- a custom nREPL handler
+       (default: `(nrepl.server/default-handler)`)
+     * :fallback -- a Ring handler for plain HTTP requests, letting
+       one route serve both this transport and the HTTP long-poll
+       transport of `drawbridge.core/ring-handler`
+       (default: respond with 426 Upgrade Required)
+
+   No param middleware is needed, in contrast to
+   `drawbridge.core/ring-handler`."
+  [& {:keys [nrepl-handler fallback]
+      :or {nrepl-handler (server/default-handler)
+           fallback (constantly upgrade-required-response)}}]
+  (fn [request]
+    (if (ws/upgrade-request? request)
+      {::ws/listener
+       {:on-open (fn [_socket])
+        :on-message (fn [socket message]
+                      (let [msg (json/parse-string (str message) true)
+                            transport (websocket-transport socket)]
+                        (future (server/handle* msg nrepl-handler transport))))
+        :on-error (fn [socket _throwable]
+                    (when (ws/open? socket)
+                      (ws/close socket 1011 "nREPL transport error")))
+        :on-close (fn [_socket _code _reason])}}
+      (fallback request))))

--- a/src/drawbridge/websocket_client.clj
+++ b/src/drawbridge/websocket_client.clj
@@ -1,0 +1,82 @@
+(ns drawbridge.websocket-client
+  "WebSocket transport support for nREPL, client side.
+
+  Connects to endpoints implemented by
+  `drawbridge.websocket/ring-handler`. Responses are pushed by the
+  server as they are produced, so unlike the HTTP long-poll transport
+  in `drawbridge.client` there is no polling and no added latency.
+
+  Uses the JDK's built-in WebSocket client (java.net.http), so no
+  extra dependencies are required."
+  (:require
+   [cheshire.core :as json]
+   [nrepl.core :as nrepl]
+   [nrepl.transport :as transport])
+  (:import
+   (java.net URI)
+   (java.net.http HttpClient WebSocket WebSocket$Listener)
+   (java.util.concurrent LinkedBlockingQueue TimeUnit)))
+
+(defn- queueing-listener
+  "A WebSocket listener that reassembles text frames into complete
+  messages, JSON-decodes them, and puts them on `incoming`."
+  [^LinkedBlockingQueue incoming closed?]
+  (let [buf (StringBuilder.)]
+    (reify WebSocket$Listener
+      (onOpen [_this ws]
+        (.request ws 1))
+      (onText [_this ws data last?]
+        ;; A logical message may span multiple frames; accumulate
+        ;; until the final one.
+        (.append buf data)
+        (when last?
+          (let [s (.toString buf)]
+            (.setLength buf 0)
+            (.put incoming (json/parse-string s true))))
+        (.request ws 1)
+        nil)
+      (onError [_this _ws _err]
+        (reset! closed? true))
+      (onClose [_this _ws _code _reason]
+        (reset! closed? true)
+        nil))))
+
+(defn websocket-client-transport
+  "Returns an nREPL client-side transport speaking JSON over
+   WebSocket, for endpoints implemented by
+   `drawbridge.websocket/ring-handler`.
+
+   Accepts an options map with the following keys:
+
+   * `:http-headers` -- extra headers to send with the upgrade request,
+     e.g. {\"Authorization\" \"Bearer <token>\"}
+
+   This fn is implicitly registered as the implementation of
+   `nrepl.core/url-connect` for the `ws` and `wss` schemes."
+  ([url] (websocket-client-transport url nil))
+  ([url {:keys [http-headers]}]
+   (let [incoming (LinkedBlockingQueue.)
+         closed? (atom false)
+         builder (reduce-kv (fn [b k v] (.header b (name k) (str v)))
+                            (.newWebSocketBuilder (HttpClient/newHttpClient))
+                            (or http-headers {}))
+         ^WebSocket ws (-> builder
+                           (.buildAsync (URI/create url)
+                                        (queueing-listener incoming closed?))
+                           (.join))
+         send-lock (Object.)]
+     (transport/->FnTransport
+      (fn read [timeout]
+        (.poll incoming timeout TimeUnit/MILLISECONDS))
+      (fn write [msg]
+        ;; The JDK client allows only one outstanding text send.
+        (locking send-lock
+          (.join (.sendText ws (json/generate-string msg) true))))
+      (fn close []
+        (when (compare-and-set! closed? false true)
+          (try
+            (.join (.sendClose ws WebSocket/NORMAL_CLOSURE "bye"))
+            (catch Exception _))))))))
+
+(.addMethod nrepl/url-connect "ws" #'websocket-client-transport)
+(.addMethod nrepl/url-connect "wss" #'websocket-client-transport)

--- a/src/drawbridge/websocket_client.clj
+++ b/src/drawbridge/websocket_client.clj
@@ -10,12 +10,19 @@
   extra dependencies are required."
   (:require
    [cheshire.core :as json]
+   [drawbridge.client :as client]
    [nrepl.core :as nrepl]
    [nrepl.transport :as transport])
   (:import
-   (java.net URI)
+   (java.net SocketException URI)
    (java.net.http HttpClient WebSocket WebSocket$Listener)
    (java.util.concurrent LinkedBlockingQueue TimeUnit)))
+
+(defonce ^:private http-client
+  ;; One shared client: each JDK HttpClient owns selector/executor
+  ;; threads that live until GC, and a single client is documented
+  ;; thread-safe and can back any number of WebSockets.
+  (delay (HttpClient/newHttpClient)))
 
 (defn- queueing-listener
   "A WebSocket listener that reassembles text frames into complete
@@ -49,17 +56,20 @@
    Accepts an options map with the following keys:
 
    * `:http-headers` -- extra headers to send with the upgrade request,
-     e.g. {\"Authorization\" \"Bearer <token>\"}
+     e.g. {\"Authorization\" \"Bearer <token>\"}. When nil or absent,
+     falls back to `drawbridge.client/default-http-headers` (the nREPL
+     config); pass an empty map to send none despite the config.
 
    This fn is implicitly registered as the implementation of
    `nrepl.core/url-connect` for the `ws` and `wss` schemes."
   ([url] (websocket-client-transport url nil))
   ([url {:keys [http-headers]}]
-   (let [incoming (LinkedBlockingQueue.)
+   (let [http-headers (or http-headers client/default-http-headers)
+         incoming (LinkedBlockingQueue.)
          closed? (atom false)
          builder (reduce-kv (fn [b k v] (.header b (name k) (str v)))
-                            (.newWebSocketBuilder (HttpClient/newHttpClient))
-                            (or http-headers {}))
+                            (.newWebSocketBuilder ^HttpClient @http-client)
+                            http-headers)
          ^WebSocket ws (-> builder
                            (.buildAsync (URI/create url)
                                         (queueing-listener incoming closed?))
@@ -67,7 +77,14 @@
          send-lock (Object.)]
      (transport/->FnTransport
       (fn read [timeout]
-        (.poll incoming timeout TimeUnit/MILLISECONDS))
+        ;; Drain anything already queued, then surface closure the
+        ;; same way the bencode socket transport does -- readers
+        ;; (e.g. the bridge relay) must be able to tell a dead
+        ;; connection from an idle one.
+        (or (.poll incoming timeout TimeUnit/MILLISECONDS)
+            (when @closed?
+              (throw (SocketException.
+                      "The WebSocket connection to the nREPL endpoint is closed")))))
       (fn write [msg]
         ;; The JDK client allows only one outstanding text send.
         (locking send-lock

--- a/test/drawbridge/auth_test.clj
+++ b/test/drawbridge/auth_test.clj
@@ -67,15 +67,14 @@
         (testing "client with the right token can eval"
           (with-open [conn (client/ring-client-transport
                             url {:http-headers {"Authorization" "Bearer s3cret"}})]
-            (let [client (nrepl/client conn 5000)
+            (let [client (nrepl/client conn 20000)
                   responses (nrepl/message client {:op "eval" :code "(+ 1 2)"})]
               (is (some #(= "3" (:value %)) responses)))))
 
-        (testing "client without the token is rejected"
-          (with-open [conn (client/ring-client-transport url)]
-            (let [client (nrepl/client conn 1000)]
-              (is (thrown? Exception
-                           (doall (nrepl/message client {:op "eval" :code "(+ 1 2)"})))))))))))
+        (testing "client without the token is rejected at connect time"
+          ;; The transport establishes its session eagerly, so a 401
+          ;; surfaces when the transport is created.
+          (is (thrown? Exception (client/ring-client-transport url))))))))
 
 (deftest secure-end-to-end-bridge
   (testing "socket client -> bridge --token -> secured endpoint"
@@ -86,7 +85,10 @@
                   :http-headers {"Authorization" "Bearer s3cret"}})]
           (try
             (with-open [conn (nrepl/connect :port (:port b))]
-              (let [client (nrepl/client conn 5000)
+              ;; Generous window: nrepl/message returns as soon as
+              ;; :status done arrives, so this only pays off on slow
+              ;; (cold-JIT CI) runs.
+              (let [client (nrepl/client conn 20000)
                     responses (nrepl/message client {:op "eval" :code "(* 6 7)"})]
                 (is (some #(= "42" (:value %)) responses))))
             (finally (bridge/stop-bridge b))))))))

--- a/test/drawbridge/auth_test.clj
+++ b/test/drawbridge/auth_test.clj
@@ -1,0 +1,92 @@
+(ns drawbridge.auth-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [cheshire.core :as json]
+            [drawbridge.auth :as auth]
+            [drawbridge.bridge :as bridge]
+            [drawbridge.client :as client]
+            [drawbridge.core :as drawbridge]
+            [nrepl.core :as nrepl]
+            [ring.adapter.jetty :as jetty]))
+
+(defn- ok-handler [_] {:status 200 :body "ok"})
+
+(defn- request-with-auth [value]
+  (cond-> {:request-method :get :uri "/repl" :headers {}}
+    value (assoc-in [:headers "authorization"] value)))
+
+(deftest wrap-token-test
+  (let [handler (auth/wrap-token ok-handler "s3cret")]
+    (testing "no Authorization header is rejected"
+      (let [resp (handler (request-with-auth nil))]
+        (is (= 401 (:status resp)))
+        (is (= "Bearer" (get-in resp [:headers "WWW-Authenticate"])))
+        (is (= "Unauthorized" (:error (json/parse-string (:body resp) true))))))
+
+    (testing "wrong token is rejected"
+      (is (= 401 (:status (handler (request-with-auth "Bearer nope"))))))
+
+    (testing "token in a non-bearer scheme is rejected"
+      (is (= 401 (:status (handler (request-with-auth "Basic s3cret"))))))
+
+    (testing "correct token passes through"
+      (is (= 200 (:status (handler (request-with-auth "Bearer s3cret"))))))
+
+    (testing "bearer scheme is case-insensitive"
+      (is (= 200 (:status (handler (request-with-auth "bearer s3cret")))))))
+
+  (testing "an empty token is not a valid configuration"
+    (is (thrown? AssertionError (auth/wrap-token ok-handler "")))))
+
+(deftest secure-ring-handler-config
+  (testing "refuses to build an unauthenticated endpoint by default"
+    (is (thrown-with-msg? IllegalArgumentException #"Refusing"
+                          (drawbridge/secure-ring-handler))))
+
+  (testing ":insecure true is a deliberate opt-out"
+    (is (fn? (drawbridge/secure-ring-handler :insecure true))))
+
+  (testing ":token yields a guarded endpoint"
+    (let [handler (drawbridge/secure-ring-handler :token "s3cret")]
+      (is (= 401 (:status (handler (request-with-auth nil)))))
+      (is (= 200 (:status (handler (-> (request-with-auth "Bearer s3cret")))))))))
+
+(defn- with-secure-server
+  "Run `f` with the port of a Jetty server exposing a token-guarded
+  Drawbridge endpoint at /."
+  [token f]
+  (let [server (jetty/run-jetty (drawbridge/secure-ring-handler :token token)
+                                {:port 0 :join? false})]
+    (try
+      (f (.getLocalPort (first (.getConnectors server))))
+      (finally (.stop server)))))
+
+(deftest secure-end-to-end-url-connect
+  (with-secure-server "s3cret"
+    (fn [port]
+      (let [url (str "http://localhost:" port "/")]
+        (testing "client with the right token can eval"
+          (with-open [conn (client/ring-client-transport
+                            url {:http-headers {"Authorization" "Bearer s3cret"}})]
+            (let [client (nrepl/client conn 5000)
+                  responses (nrepl/message client {:op "eval" :code "(+ 1 2)"})]
+              (is (some #(= "3" (:value %)) responses)))))
+
+        (testing "client without the token is rejected"
+          (with-open [conn (client/ring-client-transport url)]
+            (let [client (nrepl/client conn 1000)]
+              (is (thrown? Exception
+                           (doall (nrepl/message client {:op "eval" :code "(+ 1 2)"})))))))))))
+
+(deftest secure-end-to-end-bridge
+  (testing "socket client -> bridge --token -> secured endpoint"
+    (with-secure-server "s3cret"
+      (fn [port]
+        (let [b (bridge/start-bridge
+                 {:url (str "http://localhost:" port "/")
+                  :http-headers {"Authorization" "Bearer s3cret"}})]
+          (try
+            (with-open [conn (nrepl/connect :port (:port b))]
+              (let [client (nrepl/client conn 5000)
+                    responses (nrepl/message client {:op "eval" :code "(* 6 7)"})]
+                (is (some #(= "42" (:value %)) responses))))
+            (finally (bridge/stop-bridge b))))))))

--- a/test/drawbridge/bridge_test.clj
+++ b/test/drawbridge/bridge_test.clj
@@ -45,7 +45,7 @@
 ;; transport -- the same path editors and rebel-readline take.
 (deftest socket-client-eval
   (with-open [conn (nrepl/connect :port *bridge-port*)]
-    (let [client (nrepl/client conn 5000)]
+    (let [client (nrepl/client conn 20000)]
       (testing "a plain socket nREPL client can eval through the bridge"
         (is (= {:value "3" :ns "user"}
                (send-message client {:op "eval" :code "(+ 1 2)"}))))
@@ -60,7 +60,7 @@
 
 (deftest socket-client-describe
   (with-open [conn (nrepl/connect :port *bridge-port*)]
-    (let [client (nrepl/client conn 5000)]
+    (let [client (nrepl/client conn 20000)]
       (testing "describe lists ops, as editors expect during handshake"
         (is (some? (:ops (send-message client {:op "describe"}))))))))
 
@@ -91,7 +91,7 @@
                                        :http-headers {"Authorization" "Bearer s3cret"}})]
       (try
         (with-open [conn (nrepl/connect :port (:port bridge))]
-          (let [client (nrepl/client conn 5000)]
+          (let [client (nrepl/client conn 20000)]
             (is (= "3" (:value (send-message client {:op "eval" :code "(+ 1 2)"}))))
             (is (= #{"Bearer s3cret"} @seen))))
         (finally
@@ -158,12 +158,12 @@
                                 :idle-poll-ms 1000})]
     (try
       (with-open [conn (nrepl/connect :port (:port b))]
-        (let [client (nrepl/client conn 5000)]
+        (let [client (nrepl/client conn 20000)]
           (is (= "3" (:value (send-message client {:op "eval" :code "(+ 1 2)"}))))
-          ;; Let the connection go idle past :idle-after-ms, then
+          ;; Let the connection go idle well past :idle-after-ms, then
           ;; measure the poll rate over 2s. Eager polling would fire
           ;; ~20 GETs; backed off it's ~2.
-          (Thread/sleep 500)
+          (Thread/sleep 1000)
           (reset! get-count 0)
           (Thread/sleep 2000)
           (is (< @get-count 8) "idle connection should poll slowly")))

--- a/test/drawbridge/bridge_test.clj
+++ b/test/drawbridge/bridge_test.clj
@@ -108,3 +108,65 @@
 
 (deftest start-requires-url
   (is (thrown? IllegalArgumentException (bridge/start-bridge {}))))
+
+(deftest parse-args-test
+  (let [parse #'bridge/parse-args]
+    (testing "defaults"
+      (is (= {:url "http://x/repl" :port 7888 :bind "127.0.0.1"}
+             (parse ["--url" "http://x/repl"]))))
+
+    (testing "explicit port and bind"
+      (is (= {:url "http://x/repl" :port 9999 :bind "0.0.0.0"}
+             (parse ["--url" "http://x/repl" "--port" "9999" "--bind" "0.0.0.0"]))))
+
+    (testing "token becomes a bearer Authorization header"
+      (is (= {"Authorization" "Bearer s3cret"}
+             (:http-headers (parse ["--url" "http://x/repl" "--token" "s3cret"])))))
+
+    (testing "missing url parses to nil (caller decides to bail)"
+      (is (nil? (:url (parse [])))))))
+
+(deftest bencode-safe-test
+  (let [f #'bridge/bencode-safe]
+    (testing "nil-valued entries are dropped at any depth"
+      (is (= {:a 1} (f {:a 1 :b nil})))
+      (is (= {:m {:k 1}} (f {:m {:k 1 :gone nil}}))))
+
+    (testing "booleans and non-integer numbers become strings"
+      (is (= {:pretty "true"} (f {:pretty true})))
+      (is (= {:x "1.5"} (f {:x 1.5})))
+      (is (= {:v ["false" 2]} (f {:v [false 2]}))))
+
+    (testing "ordinary messages pass through unchanged"
+      (is (= {:value "3" :status ["done"] :id 7}
+             (f {:value "3" :status ["done"] :id 7}))))))
+
+(deftest idle-polling-backs-off
+  (let [get-count (atom 0)
+        nrepl-handler (drawbridge/ring-handler)
+        handler (-> (fn [request]
+                      (when (= :get (:request-method request))
+                        (swap! get-count inc))
+                      (nrepl-handler request))
+                    wrap-keyword-params
+                    wrap-nested-params
+                    wrap-params)
+        server (jetty/run-jetty handler {:port 0 :join? false})
+        port (.getLocalPort (first (.getConnectors server)))
+        b (bridge/start-bridge {:url (str "http://localhost:" port "/repl")
+                                :idle-after-ms 200
+                                :idle-poll-ms 1000})]
+    (try
+      (with-open [conn (nrepl/connect :port (:port b))]
+        (let [client (nrepl/client conn 5000)]
+          (is (= "3" (:value (send-message client {:op "eval" :code "(+ 1 2)"}))))
+          ;; Let the connection go idle past :idle-after-ms, then
+          ;; measure the poll rate over 2s. Eager polling would fire
+          ;; ~20 GETs; backed off it's ~2.
+          (Thread/sleep 500)
+          (reset! get-count 0)
+          (Thread/sleep 2000)
+          (is (< @get-count 8) "idle connection should poll slowly")))
+      (finally
+        (bridge/stop-bridge b)
+        (.stop server)))))

--- a/test/drawbridge/bridge_test.clj
+++ b/test/drawbridge/bridge_test.clj
@@ -1,0 +1,110 @@
+(ns drawbridge.bridge-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [compojure.core :refer [ANY defroutes]]
+            [drawbridge.bridge :as bridge]
+            [drawbridge.core :as drawbridge]
+            [nrepl.core :as nrepl]
+            [ring.adapter.jetty :as jetty]
+            [ring.middleware.keyword-params :refer [wrap-keyword-params]]
+            [ring.middleware.nested-params :refer [wrap-nested-params]]
+            [ring.middleware.params :refer [wrap-params]]))
+
+(let [nrepl-handler (drawbridge/ring-handler)]
+  (defroutes app
+    (ANY "/repl" request (nrepl-handler request))))
+
+(def ^:dynamic *bridge-port* nil)
+(def ^:dynamic *repl-url* nil)
+
+(defn bridge-fixture
+  [f]
+  (let [server (jetty/run-jetty (-> #'app wrap-keyword-params wrap-nested-params wrap-params)
+                                {:port 0 :join? false})
+        http-port (.getLocalPort (first (.getConnectors server)))
+        url (str "http://localhost:" http-port "/repl")
+        bridge (bridge/start-bridge {:url url})]
+    (try
+      (binding [*bridge-port* (:port bridge)
+                *repl-url* url]
+        (f))
+      (finally
+        (bridge/stop-bridge bridge)
+        (.stop server)))))
+
+(use-fixtures :once bridge-fixture)
+
+(defn- send-message
+  "Send a message over a client and return the first response without
+  the per-run :id/:session keys."
+  [client message]
+  (-> (nrepl/message client message)
+      first
+      (dissoc :id :session)))
+
+;; Connecting with nrepl/connect uses the plain bencode socket
+;; transport -- the same path editors and rebel-readline take.
+(deftest socket-client-eval
+  (with-open [conn (nrepl/connect :port *bridge-port*)]
+    (let [client (nrepl/client conn 5000)]
+      (testing "a plain socket nREPL client can eval through the bridge"
+        (is (= {:value "3" :ns "user"}
+               (send-message client {:op "eval" :code "(+ 1 2)"}))))
+
+      (testing "stdout is relayed back"
+        (let [messages (nrepl/message client {:op "eval" :code "(println \"hello\")"})]
+          (is (some #(= "hello\n" (:out %)) messages))))
+
+      (testing "state is preserved across evals on the same connection"
+        (send-message client {:op "eval" :code "(def bridged 41)"})
+        (is (= "42" (:value (send-message client {:op "eval" :code "(inc bridged)"}))))))))
+
+(deftest socket-client-describe
+  (with-open [conn (nrepl/connect :port *bridge-port*)]
+    (let [client (nrepl/client conn 5000)]
+      (testing "describe lists ops, as editors expect during handshake"
+        (is (some? (:ops (send-message client {:op "describe"}))))))))
+
+(deftest connection-isolation
+  (testing "concurrent local connections get separate remote sessions"
+    (with-open [conn-a (nrepl/connect :port *bridge-port*)
+                conn-b (nrepl/connect :port *bridge-port*)]
+      (let [client-a (nrepl/client conn-a 5000)
+            client-b (nrepl/client conn-b 5000)]
+        (send-message client-a {:op "eval" :code "(def isolated :a)"})
+        (is (= "3" (:value (send-message client-a {:op "eval" :code "(+ 1 2)"}))))
+        (is (= "30" (:value (send-message client-b {:op "eval" :code "(+ 10 20)"}))))))))
+
+(deftest http-headers-are-forwarded
+  (testing "bridge sends configured headers on every request"
+    (let [seen (atom #{})
+          nrepl-handler (drawbridge/ring-handler)
+          handler (-> (fn [request]
+                        (when-let [auth (get-in request [:headers "authorization"])]
+                          (swap! seen conj auth))
+                        (nrepl-handler request))
+                      wrap-keyword-params
+                      wrap-nested-params
+                      wrap-params)
+          server (jetty/run-jetty handler {:port 0 :join? false})
+          port (.getLocalPort (first (.getConnectors server)))
+          bridge (bridge/start-bridge {:url (str "http://localhost:" port "/repl")
+                                       :http-headers {"Authorization" "Bearer s3cret"}})]
+      (try
+        (with-open [conn (nrepl/connect :port (:port bridge))]
+          (let [client (nrepl/client conn 5000)]
+            (is (= "3" (:value (send-message client {:op "eval" :code "(+ 1 2)"}))))
+            (is (= #{"Bearer s3cret"} @seen))))
+        (finally
+          (bridge/stop-bridge bridge)
+          (.stop server))))))
+
+(deftest stop-closes-listener
+  (testing "after stop-bridge the port no longer accepts connections"
+    (let [bridge (bridge/start-bridge {:url *repl-url*})
+          port (:port bridge)]
+      (bridge/stop-bridge bridge)
+      (is (thrown? java.net.ConnectException
+                   (.close (java.net.Socket. "127.0.0.1" (int port))))))))
+
+(deftest start-requires-url
+  (is (thrown? IllegalArgumentException (bridge/start-bridge {}))))

--- a/test/drawbridge/client_test.clj
+++ b/test/drawbridge/client_test.clj
@@ -19,7 +19,7 @@
 (defn server-fixture
   [f]
   (let [server (jetty/run-jetty (-> #'app wrap-keyword-params wrap-nested-params wrap-params)
-                               {:port 0 :join? false})
+                                {:port 0 :join? false})
         port (.getLocalPort (first (.getConnectors server)))]
     (try
       (binding [*port* port]
@@ -85,6 +85,32 @@
             client-b (nrepl/client conn-b 1000)]
         (is (= "3" (:value (send-message client-a {:op "eval" :code "(+ 1 2)"}))))
         (is (= "30" (:value (send-message client-b {:op "eval" :code "(+ 10 20)"}))))))))
+
+(deftest nil-http-headers-fall-back-to-config
+  (testing "an explicit nil :http-headers still gets the config default"
+    (let [seen (atom #{})
+          nrepl-handler (drawbridge/ring-handler)
+          handler (-> (fn [request]
+                        (when-let [auth (get-in request [:headers "authorization"])]
+                          (swap! seen conj auth))
+                        (nrepl-handler request))
+                      wrap-keyword-params
+                      wrap-nested-params
+                      wrap-params)
+          server (jetty/run-jetty handler {:port 0 :join? false})
+          port (.getLocalPort (first (.getConnectors server)))]
+      (try
+        (with-redefs [drawbridge.client/default-http-headers
+                      {"Authorization" "Bearer from-config"}]
+          (with-open [conn (drawbridge.client/ring-client-transport
+                            (str "http://localhost:" port "/repl")
+                            {:http-headers nil})]
+            (let [client (nrepl/client conn 5000)]
+              (is (= {:value "3" :ns "user"}
+                     (send-message client {:op "eval" :code "(+ 1 2)"}))))))
+        (is (= #{"Bearer from-config"} @seen))
+        (finally
+          (.stop server))))))
 
 (deftest polling-is-throttled
   (let [get-count (atom 0)

--- a/test/drawbridge/websocket_test.clj
+++ b/test/drawbridge/websocket_test.clj
@@ -2,9 +2,11 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [drawbridge.auth :as auth]
             [drawbridge.bridge :as bridge]
+            [drawbridge.client]
             [drawbridge.websocket :as websocket]
             [drawbridge.websocket-client]
             [nrepl.core :as nrepl]
+            [nrepl.transport :as transport]
             [ring.adapter.jetty :as jetty]))
 
 (def ^:dynamic *port* nil)
@@ -106,3 +108,88 @@
           (let [client (nrepl/client conn 5000)]
             (is (= "42" (:value (send-message client {:op "eval" :code "(* 6 7)"}))))))
         (finally (bridge/stop-bridge b))))))
+
+(defn- counting-ws-handler
+  "Wrap a websocket ring-handler so `open-count` tracks currently-open
+  server-side WebSocket connections."
+  [base open-count]
+  (fn [req]
+    (let [resp (base req)]
+      (if-let [listener (:ring.websocket/listener resp)]
+        (assoc resp :ring.websocket/listener
+               (-> listener
+                   (update :on-open (fn [f]
+                                      (fn [socket]
+                                        (swap! open-count inc)
+                                        (f socket))))
+                   (update :on-close (fn [f]
+                                       (fn [socket code reason]
+                                         (swap! open-count dec)
+                                         (f socket code reason))))))
+        resp))))
+
+(defn- await-value
+  "Poll until (pred) is true or `ms` elapse."
+  [pred ms]
+  (let [deadline (+ (System/currentTimeMillis) ms)]
+    (while (and (not (pred)) (< (System/currentTimeMillis) deadline))
+      (Thread/sleep 50))
+    (pred)))
+
+(deftest bridge-closes-remote-connection
+  (testing "local disconnect closes the remote WebSocket (no leak)"
+    (let [open-count (atom 0)
+          handler (counting-ws-handler (websocket/ring-handler) open-count)
+          server (jetty/run-jetty handler {:port 0 :join? false})
+          port (.getLocalPort (first (.getConnectors server)))
+          b (bridge/start-bridge {:url (str "ws://localhost:" port "/")})]
+      (try
+        (with-open [conn (nrepl/connect :port (:port b))]
+          (let [client (nrepl/client conn 5000)]
+            (is (= "3" (:value (send-message client {:op "eval" :code "(+ 1 2)"}))))
+            (is (= 1 @open-count))))
+        ;; with-open closed the local socket; the relay must release
+        ;; the remote WebSocket in response.
+        (is (await-value #(zero? @open-count) 5000)
+            "remote WebSocket should close after local disconnect")
+        (finally
+          (bridge/stop-bridge b)
+          (.stop server))))))
+
+(deftest bridge-detects-remote-death
+  (testing "when the remote ws endpoint dies, the local socket is closed"
+    (let [server (jetty/run-jetty (websocket/ring-handler) {:port 0 :join? false})
+          port (.getLocalPort (first (.getConnectors server)))
+          b (bridge/start-bridge {:url (str "ws://localhost:" port "/")})
+          conn (nrepl/connect :port (:port b))]
+      (try
+        (let [client (nrepl/client conn 5000)]
+          (is (= "3" (:value (send-message client {:op "eval" :code "(+ 1 2)"})))))
+        (.stop server)
+        ;; The relay should notice the dead remote and close our
+        ;; socket; a read on it then throws instead of hanging forever.
+        (is (thrown? Exception
+                     (let [deadline (+ (System/currentTimeMillis) 10000)]
+                       (loop []
+                         (transport/recv conn 100)
+                         (when (< (System/currentTimeMillis) deadline)
+                           (recur)))))
+            "local socket should be closed once the remote dies")
+        (finally
+          (try (.close conn) (catch Exception _))
+          (bridge/stop-bridge b))))))
+
+(deftest ws-client-uses-config-headers
+  (testing "wss/ws transport falls back to the .nrepl.edn header config"
+    (let [handler (auth/wrap-token (websocket/ring-handler) "cfg-secret")
+          server (jetty/run-jetty handler {:port 0 :join? false})
+          port (.getLocalPort (first (.getConnectors server)))]
+      (try
+        (with-redefs [drawbridge.client/default-http-headers
+                      {"Authorization" "Bearer cfg-secret"}]
+          (with-open [conn (drawbridge.websocket-client/websocket-client-transport
+                            (str "ws://localhost:" port "/"))]
+            (let [client (nrepl/client conn 5000)]
+              (is (= "3" (:value (send-message client {:op "eval" :code "(+ 1 2)"})))))))
+        (finally
+          (.stop server))))))

--- a/test/drawbridge/websocket_test.clj
+++ b/test/drawbridge/websocket_test.clj
@@ -1,0 +1,108 @@
+(ns drawbridge.websocket-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [drawbridge.auth :as auth]
+            [drawbridge.bridge :as bridge]
+            [drawbridge.websocket :as websocket]
+            [drawbridge.websocket-client]
+            [nrepl.core :as nrepl]
+            [ring.adapter.jetty :as jetty]))
+
+(def ^:dynamic *port* nil)
+
+(defn server-fixture
+  [f]
+  (let [server (jetty/run-jetty (websocket/ring-handler)
+                                {:port 0 :join? false})]
+    (try
+      (binding [*port* (.getLocalPort (first (.getConnectors server)))]
+        (f))
+      (finally
+        (.stop server)))))
+
+(use-fixtures :once server-fixture)
+
+(defn- ws-url [] (str "ws://localhost:" *port* "/"))
+
+(defn- send-message
+  [client message]
+  (-> (nrepl/message client message)
+      first
+      (dissoc :id :session)))
+
+(deftest websocket-eval
+  ;; url-connect dispatches on the ws scheme thanks to the
+  ;; registration in drawbridge.websocket-client.
+  (with-open [conn (nrepl/url-connect (ws-url))]
+    (let [client (nrepl/client conn 5000)]
+      (testing "eval returns value and namespace"
+        (is (= {:value "3" :ns "user"}
+               (send-message client {:op "eval" :code "(+ 1 2)"}))))
+
+      (testing "stdout is pushed back"
+        (let [messages (nrepl/message client {:op "eval" :code "(println \"hello\")"})]
+          (is (some #(= "hello\n" (:out %)) messages))))
+
+      (testing "state is preserved within a session"
+        (send-message client {:op "eval" :code "(def ws-x 42)"})
+        (is (= "42" (:value (send-message client {:op "eval" :code "ws-x"})))))
+
+      (testing "describe works"
+        (is (some? (:ops (send-message client {:op "describe"}))))))))
+
+(deftest websocket-streaming
+  (testing "incremental output is pushed as separate messages"
+    (with-open [conn (nrepl/url-connect (ws-url))]
+      (let [client (nrepl/client conn 5000)
+            messages (nrepl/message
+                      client
+                      {:op "eval"
+                       :code "(dotimes [i 3] (println i) (Thread/sleep 20))"})
+            outs (keep :out messages)]
+        ;; Chunk boundaries aren't guaranteed (nREPL may coalesce
+        ;; output), but content and order are.
+        (is (= "0\n1\n2\n" (apply str outs)))))))
+
+(deftest websocket-client-isolation
+  (testing "concurrent connections receive their own responses"
+    (with-open [conn-a (nrepl/url-connect (ws-url))
+                conn-b (nrepl/url-connect (ws-url))]
+      (let [client-a (nrepl/client conn-a 5000)
+            client-b (nrepl/client conn-b 5000)]
+        (is (= "3" (:value (send-message client-a {:op "eval" :code "(+ 1 2)"}))))
+        (is (= "30" (:value (send-message client-b {:op "eval" :code "(+ 10 20)"}))))))))
+
+(defn- http-status
+  [url]
+  (let [conn (.openConnection (java.net.URL. url))]
+    (.getResponseCode ^java.net.HttpURLConnection conn)))
+
+(deftest plain-http-gets-upgrade-required
+  (testing "a non-upgrade request receives 426 by default"
+    (is (= 426 (http-status (str "http://localhost:" *port* "/"))))))
+
+(deftest websocket-with-token-auth
+  (let [handler (auth/wrap-token (websocket/ring-handler) "s3cret")
+        server (jetty/run-jetty handler {:port 0 :join? false})
+        port (.getLocalPort (first (.getConnectors server)))
+        url (str "ws://localhost:" port "/")]
+    (try
+      (testing "upgrade with the right token connects and evals"
+        (with-open [conn (drawbridge.websocket-client/websocket-client-transport
+                          url {:http-headers {"Authorization" "Bearer s3cret"}})]
+          (let [client (nrepl/client conn 5000)]
+            (is (= "3" (:value (send-message client {:op "eval" :code "(+ 1 2)"})))))))
+
+      (testing "upgrade without the token is rejected during handshake"
+        (is (thrown? Exception
+                     (drawbridge.websocket-client/websocket-client-transport url))))
+      (finally
+        (.stop server)))))
+
+(deftest bridge-over-websocket
+  (testing "socket client -> bridge -> ws endpoint"
+    (let [b (bridge/start-bridge {:url (ws-url)})]
+      (try
+        (with-open [conn (nrepl/connect :port (:port b))]
+          (let [client (nrepl/client conn 5000)]
+            (is (= "42" (:value (send-message client {:op "eval" :code "(* 6 7)"}))))))
+        (finally (bridge/stop-bridge b))))))

--- a/test/drawbridge/websocket_test.clj
+++ b/test/drawbridge/websocket_test.clj
@@ -35,7 +35,7 @@
   ;; url-connect dispatches on the ws scheme thanks to the
   ;; registration in drawbridge.websocket-client.
   (with-open [conn (nrepl/url-connect (ws-url))]
-    (let [client (nrepl/client conn 5000)]
+    (let [client (nrepl/client conn 20000)]
       (testing "eval returns value and namespace"
         (is (= {:value "3" :ns "user"}
                (send-message client {:op "eval" :code "(+ 1 2)"}))))
@@ -54,7 +54,7 @@
 (deftest websocket-streaming
   (testing "incremental output is pushed as separate messages"
     (with-open [conn (nrepl/url-connect (ws-url))]
-      (let [client (nrepl/client conn 5000)
+      (let [client (nrepl/client conn 20000)
             messages (nrepl/message
                       client
                       {:op "eval"
@@ -91,7 +91,7 @@
       (testing "upgrade with the right token connects and evals"
         (with-open [conn (drawbridge.websocket-client/websocket-client-transport
                           url {:http-headers {"Authorization" "Bearer s3cret"}})]
-          (let [client (nrepl/client conn 5000)]
+          (let [client (nrepl/client conn 20000)]
             (is (= "3" (:value (send-message client {:op "eval" :code "(+ 1 2)"})))))))
 
       (testing "upgrade without the token is rejected during handshake"
@@ -105,7 +105,7 @@
     (let [b (bridge/start-bridge {:url (ws-url)})]
       (try
         (with-open [conn (nrepl/connect :port (:port b))]
-          (let [client (nrepl/client conn 5000)]
+          (let [client (nrepl/client conn 20000)]
             (is (= "42" (:value (send-message client {:op "eval" :code "(* 6 7)"}))))))
         (finally (bridge/stop-bridge b))))))
 
@@ -145,7 +145,7 @@
           b (bridge/start-bridge {:url (str "ws://localhost:" port "/")})]
       (try
         (with-open [conn (nrepl/connect :port (:port b))]
-          (let [client (nrepl/client conn 5000)]
+          (let [client (nrepl/client conn 20000)]
             (is (= "3" (:value (send-message client {:op "eval" :code "(+ 1 2)"}))))
             (is (= 1 @open-count))))
         ;; with-open closed the local socket; the relay must release
@@ -163,7 +163,7 @@
           b (bridge/start-bridge {:url (str "ws://localhost:" port "/")})
           conn (nrepl/connect :port (:port b))]
       (try
-        (let [client (nrepl/client conn 5000)]
+        (let [client (nrepl/client conn 20000)]
           (is (= "3" (:value (send-message client {:op "eval" :code "(+ 1 2)"})))))
         (.stop server)
         ;; The relay should notice the dead remote and close our
@@ -189,7 +189,7 @@
                       {"Authorization" "Bearer cfg-secret"}]
           (with-open [conn (drawbridge.websocket-client/websocket-client-transport
                             (str "ws://localhost:" port "/"))]
-            (let [client (nrepl/client conn 5000)]
+            (let [client (nrepl/client conn 20000)]
               (is (= "3" (:value (send-message client {:op "eval" :code "(+ 1 2)"})))))))
         (finally
           (.stop server))))))


### PR DESCRIPTION
Drawbridge endpoints have so far been unreachable from socket-based nREPL clients (CIDER, Calva, rebel-readline, nREPL's own CLI), which limited the project to `lein repl :connect` and programmatic use. This adds a local bridge (`drawbridge.bridge`) that relays a plain nREPL socket to a remote endpoint over HTTP(S), so any editor can connect to a Drawbridge endpoint.

Since exposing a REPL over the network shouldn't be a foot-gun, there's now also `secure-ring-handler`: one form that bundles the required param middleware with constant-time bearer-token auth, and refuses to build an unauthenticated endpoint unless you opt out explicitly with `:insecure true`.

Finally, a WebSocket transport (server and client) replaces HTTP long-polling with real server push where the deployment environment allows it. The bridge picks it automatically for `ws(s)://` URLs, so editors get push end to end. Closes #44.

The README documents all three, and everything is covered by tests across the Clojure 1.10/1.11/1.12 matrix.