### PR TITLE
Survive remote connection failures in the bridge accept loop

### DIFF
--- a/src/drawbridge/bridge.clj
+++ b/src/drawbridge/bridge.clj
@@ -70,8 +70,11 @@
   endpoint at `url` until either side disconnects. Calls `on-close`
   once when the connection winds down."
   [^Socket sock url http-headers poll-opts on-close]
-  (let [local (transport/bencode sock)
-        remote (remote-transport url http-headers)
+  ;; Open the remote side first: it's the fallible one (unreachable
+  ;; endpoint, auth rejection), and at this point no local transport
+  ;; resources exist yet for a throw to leak.
+  (let [remote (remote-transport url http-headers)
+        local (transport/bencode sock)
         {:keys [active-poll-ms idle-poll-ms idle-after-ms]} poll-opts
         open? (atom true)
         last-activity (atom (System/currentTimeMillis))
@@ -141,8 +144,19 @@
         (loop []
           (let [^Socket sock (.accept server)]
             (swap! connections conj sock)
-            (relay sock url http-headers poll-opts
-                   #(swap! connections disj sock))
+            ;; A failure to reach the remote endpoint (e.g. a 401 on
+            ;; the first request) must not kill the accept loop, and
+            ;; the local client should see its connection drop right
+            ;; away rather than hang waiting for a handshake.
+            (try
+              (relay sock url http-headers poll-opts
+                     #(swap! connections disj sock))
+              (catch Exception e
+                (swap! connections disj sock)
+                (.close sock)
+                (binding [*out* *err*]
+                  (println "drawbridge.bridge: could not connect to" url "-"
+                           (str e)))))
             (recur)))
         ;; Closing the server socket unblocks accept with an exception.
         (catch Exception _)))

--- a/test/drawbridge/auth_test.clj
+++ b/test/drawbridge/auth_test.clj
@@ -92,3 +92,20 @@
                     responses (nrepl/message client {:op "eval" :code "(* 6 7)"})]
                 (is (some #(= "42" (:value %)) responses))))
             (finally (bridge/stop-bridge b))))))))
+
+(deftest bridge-rejected-by-endpoint
+  (testing "clients of a misconfigured bridge fail fast instead of hanging"
+    (with-secure-server "s3cret"
+      (fn [port]
+        (let [b (bridge/start-bridge
+                 {:url (str "http://localhost:" port "/")
+                  :http-headers {"Authorization" "Bearer WRONG"}})]
+          (try
+            ;; Two rounds: the accept loop must also survive the
+            ;; first failed relay and keep serving new connections.
+            (dotimes [_ 2]
+              (is (thrown? Exception
+                           (with-open [conn (nrepl/connect :port (:port b))]
+                             (let [client (nrepl/client conn 20000)]
+                               (doall (nrepl/message client {:op "eval" :code "(+ 1 2)"})))))))
+            (finally (bridge/stop-bridge b))))))))


### PR DESCRIPTION
Test-driving the merged bridge end to end surfaced a bad failure mode: point the bridge at an endpoint that rejects it (e.g. a wrong `--token`) and a connecting editor hangs forever with no error, while the failed handshake silently kills the accept loop, so the bridge never serves another connection.

Now a failed relay setup closes the client socket right away (the client errors out immediately), the cause lands on the bridge's stderr, and the accept loop keeps going. Verified live against a token-guarded WebSocket endpoint: two consecutive client attempts both fail fast and the bridge stays up.