### PR TITLE
Usability polish: friendlier bridge CLI, keepalive pings, deps.edn

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,18 @@
   `drawbridge.websocket-client` client side, registered on `url-connect`
   for `ws`/`wss`) with server push instead of HTTP long-polling.
 * Add an options arity to `ring-client-transport` accepting `:http-headers`.
+* The bridge CLI writes a `.nrepl-port` file for editor auto-detection,
+  reads the token from `DRAWBRIDGE_TOKEN`, validates its arguments, and
+  supports `--help`.
+* The bridge reports connection failures to the local client as an
+  in-band `:err` message instead of just dropping the socket.
+* The WebSocket server pings connections every 30s (`:ping-interval-ms`)
+  so proxies don't drop idle REPL sessions.
+* Add a `deps.edn`, making Drawbridge usable as a git dependency.
+* https://github.com/nrepl/drawbridge/issues/11[#11]: Confirmed fixed --
+  the handler keeps its session state in a private store under its own
+  cookie and no longer clobbers the application's ring session (now
+  covered by a regression test).
 
 == 0.3.1 (2026-07-09)
 

--- a/README.adoc
+++ b/README.adoc
@@ -301,21 +301,37 @@ endpoint:
 
 [source,shell]
 ----
+export DRAWBRIDGE_TOKEN=<token>
 clojure -Sdeps '{:deps {nrepl/drawbridge {:mvn/version "0.3.1"}}}' \
-  -M -m drawbridge.bridge --url https://my-app.example.com/repl \
-  --port 7888 --token $DRAWBRIDGE_TOKEN
+  -M -m drawbridge.bridge --url https://my-app.example.com/repl --port 7888
 ----
 
 Now `cider-connect` to `localhost:7888` (or point Calva, rebel-readline,
 or any other nREPL client there) and you're evaluating code on the
-remote app. Each local connection gets its own session on the remote
-end, and `--token` is sent as an `Authorization: Bearer` header --
-pairing with `secure-ring-handler` on the server.
+remote app. The bridge writes a `.nrepl-port` file to the working
+directory (and removes it on exit), so editors that auto-detect running
+nREPL servers will find it without being told the port. Each local
+connection gets its own session on the remote end.
+
+The token is sent as an `Authorization: Bearer` header -- pairing with
+`secure-ring-handler` on the server. It can also be passed as
+`--token <token>`, though the environment variable is preferable since
+command-line arguments are visible in the process list. Run with
+`--help` for all options.
 
 The bridge can also be started programmatically with
 `drawbridge.bridge/start-bridge`. When given a `ws://` or `wss://` URL
 it speaks the WebSocket transport (see below) instead of HTTP
 long-polling, which eliminates polling latency entirely.
+
+Since Drawbridge ships a `deps.edn`, the bridge can even be run
+straight from a git coordinate, with no release involved:
+
+[source,shell]
+----
+clojure -Sdeps '{:deps {io.github.nrepl/drawbridge {:git/sha "..."}}}' \
+  -M -m drawbridge.bridge --url https://my-app.example.com/repl
+----
 
 == WebSocket transport
 
@@ -353,6 +369,11 @@ handler opts out of its own auth with `:insecure true`.)
 
 WebSocket support requires a Ring adapter that implements the Ring 1.11+
 WebSocket API -- ring-jetty-adapter does out of the box.
+
+The server pings each connection every 30 seconds by default, so
+proxies and routers (e.g. Heroku's ~55s router timeout) don't sever
+idle REPL sessions. Tune or disable this with the `:ping-interval-ms`
+option.
 
 On the client, `drawbridge.websocket-client` registers the `ws` and
 `wss` schemes with `url-connect` (using the JDK's built-in WebSocket

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,6 @@
+{:paths ["src"]
+ :deps {nrepl/nrepl {:mvn/version "1.7.0"}
+        ring/ring-core {:mvn/version "1.15.5"}
+        cheshire/cheshire {:mvn/version "6.2.0"}
+        ;; client
+        clj-http/clj-http {:mvn/version "3.13.1"}}}

--- a/src/drawbridge/bridge.clj
+++ b/src/drawbridge/bridge.clj
@@ -22,9 +22,12 @@
   speaks the WebSocket transport (`drawbridge.websocket-client`)
   instead, and responses are pushed with no polling delay."
   (:require
+   [clojure.java.io :as io]
+   [clojure.string :as str]
    [clojure.walk :as walk]
    [drawbridge.client :as client]
    [drawbridge.websocket-client :as ws-client]
+   [nrepl.bencode :as bencode]
    [nrepl.transport :as transport])
   (:import
    (java.io Closeable)
@@ -153,10 +156,19 @@
                      #(swap! connections disj sock))
               (catch Exception e
                 (swap! connections disj sock)
-                (.close sock)
-                (binding [*out* *err*]
-                  (println "drawbridge.bridge: could not connect to" url "-"
-                           (str e)))))
+                (let [reason (str "drawbridge: could not connect to " url " - " e)]
+                  ;; Best effort: nREPL clients display unsolicited
+                  ;; :err messages, so tell the user why their
+                  ;; connection is about to drop.
+                  (try
+                    (let [out (.getOutputStream sock)]
+                      (bencode/write-bencode out {"err" (str reason "\n")
+                                                  "status" ["error" "done"]})
+                      (.flush out))
+                    (catch Exception _))
+                  (.close sock)
+                  (binding [*out* *err*]
+                    (println reason)))))
             (recur)))
         ;; Closing the server socket unblocks accept with an exception.
         (catch Exception _)))
@@ -172,34 +184,82 @@
   (doseq [^Socket sock @connections]
     (.close sock)))
 
+(def ^:private usage
+  (str/join
+   "\n"
+   ["Usage: -m drawbridge.bridge --url URL [--port N] [--bind ADDR] [--token TOKEN]"
+    ""
+    "  --url URL      the remote Drawbridge endpoint (http(s):// or ws(s)://)"
+    "  --port N       local port to listen on (default 7888)"
+    "  --bind ADDR    local address to bind (default 127.0.0.1)"
+    "  --token TOKEN  sent as an Authorization: Bearer header; prefer the"
+    "                 DRAWBRIDGE_TOKEN environment variable, which doesn't"
+    "                 show up in the process list"
+    "  -h, --help     show this help"]))
+
 (defn- parse-args
   "Parse -main's `--key value` argument pairs into start-bridge
-  options. :url is nil when missing."
-  [args]
-  (let [opts (apply hash-map args)
-        token (get opts "--token")]
-    (cond-> {:url (get opts "--url")
-             :port (or (some-> (get opts "--port") Long/parseLong) 7888)
-             :bind (get opts "--bind" "127.0.0.1")}
-      token (assoc :http-headers
-                   {"Authorization" (str "Bearer " token)}))))
+  options; returns {:help true} for -h/--help. The token falls back
+  to DRAWBRIDGE_TOKEN in `env`. Throws on malformed or unknown
+  arguments; :url is nil when missing."
+  ([args] (parse-args args {"DRAWBRIDGE_TOKEN" (System/getenv "DRAWBRIDGE_TOKEN")}))
+  ([args env]
+   (if (some #{"--help" "-h"} args)
+     {:help true}
+     (do
+       (when (odd? (count args))
+         (throw (IllegalArgumentException.
+                 "Arguments must be --key value pairs (see --help)")))
+       (let [opts (apply hash-map args)
+             unknown (remove #{"--url" "--port" "--bind" "--token"} (keys opts))]
+         (when (seq unknown)
+           (throw (IllegalArgumentException.
+                   (str "Unknown argument(s): " (str/join ", " unknown)
+                        " (see --help)"))))
+         (let [token (or (get opts "--token") (get env "DRAWBRIDGE_TOKEN"))]
+           (cond-> {:url (get opts "--url")
+                    :port (or (some-> (get opts "--port") Long/parseLong) 7888)
+                    :bind (get opts "--bind" "127.0.0.1")}
+             (seq token) (assoc :http-headers
+                                {"Authorization" (str "Bearer " token)}))))))))
+
+(defn- write-port-file!
+  "Write `port` to .nrepl-port in the working directory so editors
+  (CIDER, Calva, ...) can auto-detect the bridge, and arrange for the
+  file to be removed on shutdown. Refuses to overwrite an existing
+  file -- it likely belongs to another running nREPL server."
+  ([port] (write-port-file! port (io/file ".nrepl-port")))
+  ([port ^java.io.File f]
+   (if (.exists f)
+     (binding [*out* *err*]
+       (println "drawbridge: .nrepl-port already exists; not overwriting it"))
+     (do
+       (spit f (str port))
+       (.addShutdownHook (Runtime/getRuntime)
+                         (Thread. ^Runnable #(.delete f)))))))
 
 (defn -main
-  "Command-line entry point.
-
-  Arguments (as `--key value` pairs):
-
-  * `--url URL` (required) -- the remote Drawbridge endpoint
-  * `--port N` -- local port to listen on (default 7888)
-  * `--bind ADDR` -- local address to bind (default 127.0.0.1)
-  * `--token TOKEN` -- sent as an `Authorization: Bearer` header"
+  "Command-line entry point. See `usage` (or run with --help) for the
+  accepted arguments. The bearer token can also be supplied via the
+  DRAWBRIDGE_TOKEN environment variable, which is preferable to
+  --token since arguments are visible in the process list."
   [& args]
-  (let [{:keys [url bind] :as opts} (parse-args args)]
+  (let [{:keys [url bind help] :as opts}
+        (try
+          (parse-args args)
+          (catch IllegalArgumentException e
+            (binding [*out* *err*]
+              (println (.getMessage e)))
+            (System/exit 1)))]
+    (when help
+      (println usage)
+      (System/exit 0))
     (when-not url
       (binding [*out* *err*]
-        (println "Usage: -m drawbridge.bridge --url URL [--port N] [--bind ADDR] [--token TOKEN]"))
+        (println usage))
       (System/exit 1))
     (let [bridge (start-bridge opts)]
+      (write-port-file! (:port bridge))
       (println (format "Drawbridge bridge: nREPL on %s:%d -> %s"
                        bind (:port bridge) url))
       (println "Point your nREPL client (CIDER, Calva, rebel-readline, ...) at this port.")

--- a/src/drawbridge/websocket.clj
+++ b/src/drawbridge/websocket.clj
@@ -18,7 +18,18 @@
    [cheshire.core :as json]
    [nrepl.server :as server]
    [nrepl.transport :as transport]
-   [ring.websocket :as ws]))
+   [ring.websocket :as ws])
+  (:import
+   (java.util.concurrent Executors ScheduledFuture ThreadFactory TimeUnit)))
+
+(defonce ^:private ping-scheduler
+  ;; One shared daemon thread schedules keepalive pings for all
+  ;; connections; the work per tick is a single frame write.
+  (delay (Executors/newSingleThreadScheduledExecutor
+          (reify ThreadFactory
+            (newThread [_ r]
+              (doto (Thread. r "drawbridge-ws-ping")
+                (.setDaemon true)))))))
 
 (def ^:private upgrade-required-response
   {:status 426
@@ -64,26 +75,47 @@
        one route serve both this transport and the HTTP long-poll
        transport of `drawbridge.core/ring-handler`
        (default: respond with 426 Upgrade Required)
+     * :ping-interval-ms -- how often to send a keepalive ping on
+       each connection, preventing proxies and routers from dropping
+       idle REPL sessions (default 30000; 0 disables)
 
    No param middleware is needed, in contrast to
    `drawbridge.core/ring-handler`."
-  [& {:keys [nrepl-handler fallback]
+  [& {:keys [nrepl-handler fallback ping-interval-ms]
       :or {nrepl-handler (server/default-handler)
-           fallback (constantly upgrade-required-response)}}]
+           fallback (constantly upgrade-required-response)
+           ping-interval-ms 30000}}]
   (fn [request]
     (if (ws/upgrade-request? request)
       ;; One transport per connection, so its lock serializes every
       ;; writer targeting this socket across all in-flight messages.
-      (let [transport (volatile! nil)]
+      (let [transport (volatile! nil)
+            ping-task (volatile! nil)
+            stop-pings! (fn []
+                          (when-let [^ScheduledFuture task @ping-task]
+                            (.cancel task false)))]
         {::ws/listener
          {:on-open (fn [socket]
-                     (vreset! transport (websocket-transport socket)))
+                     (vreset! transport (websocket-transport socket))
+                     (when (pos? ping-interval-ms)
+                       (vreset! ping-task
+                                (.scheduleAtFixedRate
+                                 ^java.util.concurrent.ScheduledExecutorService @ping-scheduler
+                                 #(try
+                                    (when (ws/open? socket)
+                                      (ws/ping socket))
+                                    (catch Exception _))
+                                 (long ping-interval-ms)
+                                 (long ping-interval-ms)
+                                 TimeUnit/MILLISECONDS))))
           :on-message (fn [_socket message]
                         (let [msg (json/parse-string (str message) true)
                               t @transport]
                           (future (server/handle* msg nrepl-handler t))))
           :on-error (fn [socket _throwable]
+                      (stop-pings!)
                       (when (ws/open? socket)
                         (ws/close socket 1011 "nREPL transport error")))
-          :on-close (fn [_socket _code _reason])}})
+          :on-close (fn [_socket _code _reason]
+                      (stop-pings!))}})
       (fallback request))))

--- a/test/drawbridge/auth_test.clj
+++ b/test/drawbridge/auth_test.clj
@@ -6,6 +6,7 @@
             [drawbridge.client :as client]
             [drawbridge.core :as drawbridge]
             [nrepl.core :as nrepl]
+            [nrepl.transport :as transport]
             [ring.adapter.jetty :as jetty]))
 
 (defn- ok-handler [_] {:status 200 :body "ok"})
@@ -104,8 +105,13 @@
             ;; Two rounds: the accept loop must also survive the
             ;; first failed relay and keep serving new connections.
             (dotimes [_ 2]
-              (is (thrown? Exception
-                           (with-open [conn (nrepl/connect :port (:port b))]
-                             (let [client (nrepl/client conn 20000)]
-                               (doall (nrepl/message client {:op "eval" :code "(+ 1 2)"})))))))
+              (with-open [conn (nrepl/connect :port (:port b))]
+                (testing "the reason arrives as an in-band :err message"
+                  (let [msg (transport/recv conn 20000)]
+                    (is (re-find #"drawbridge: could not connect"
+                                 (or (:err msg) "")))))
+                (testing "and the connection then drops instead of hanging"
+                  (is (thrown? Exception
+                               ;; bounded read loop: throws on close
+                               (dorun (repeatedly 100 #(transport/recv conn 200))))))))
             (finally (bridge/stop-bridge b))))))))

--- a/test/drawbridge/bridge_test.clj
+++ b/test/drawbridge/bridge_test.clj
@@ -110,21 +110,62 @@
   (is (thrown? IllegalArgumentException (bridge/start-bridge {}))))
 
 (deftest parse-args-test
-  (let [parse #'bridge/parse-args]
+  (let [parse #'bridge/parse-args
+        no-env {}]
     (testing "defaults"
       (is (= {:url "http://x/repl" :port 7888 :bind "127.0.0.1"}
-             (parse ["--url" "http://x/repl"]))))
+             (parse ["--url" "http://x/repl"] no-env))))
 
     (testing "explicit port and bind"
       (is (= {:url "http://x/repl" :port 9999 :bind "0.0.0.0"}
-             (parse ["--url" "http://x/repl" "--port" "9999" "--bind" "0.0.0.0"]))))
+             (parse ["--url" "http://x/repl" "--port" "9999" "--bind" "0.0.0.0"] no-env))))
 
     (testing "token becomes a bearer Authorization header"
       (is (= {"Authorization" "Bearer s3cret"}
-             (:http-headers (parse ["--url" "http://x/repl" "--token" "s3cret"])))))
+             (:http-headers (parse ["--url" "http://x/repl" "--token" "s3cret"] no-env)))))
+
+    (testing "token falls back to the DRAWBRIDGE_TOKEN environment variable"
+      (is (= {"Authorization" "Bearer from-env"}
+             (:http-headers (parse ["--url" "http://x/repl"]
+                                   {"DRAWBRIDGE_TOKEN" "from-env"})))))
+
+    (testing "--token wins over the environment"
+      (is (= {"Authorization" "Bearer explicit"}
+             (:http-headers (parse ["--url" "http://x/repl" "--token" "explicit"]
+                                   {"DRAWBRIDGE_TOKEN" "from-env"})))))
+
+    (testing "-h/--help short-circuit"
+      (is (= {:help true} (parse ["--help"] no-env)))
+      (is (= {:help true} (parse ["-h"] no-env)))
+      (is (= {:help true} (parse ["--url" "http://x/" "--help"] no-env))))
+
+    (testing "unknown arguments are rejected, not silently ignored"
+      (is (thrown-with-msg? IllegalArgumentException #"Unknown argument.*--prot"
+                            (parse ["--url" "http://x/" "--prot" "7888"] no-env))))
+
+    (testing "an odd number of arguments is rejected with a clear message"
+      (is (thrown-with-msg? IllegalArgumentException #"--key value pairs"
+                            (parse ["--url"] no-env))))
 
     (testing "missing url parses to nil (caller decides to bail)"
-      (is (nil? (:url (parse [])))))))
+      (is (nil? (:url (parse [] no-env)))))))
+
+(deftest write-port-file-test
+  (let [write! #'bridge/write-port-file!
+        dir (java.nio.file.Files/createTempDirectory
+             "drawbridge-test" (make-array java.nio.file.attribute.FileAttribute 0))
+        f (.toFile (.resolve dir ".nrepl-port"))]
+    (try
+      (testing "writes the port for editor auto-detection"
+        (write! 7888 f)
+        (is (= "7888" (slurp f))))
+
+      (testing "refuses to overwrite an existing port file"
+        (write! 9999 f)
+        (is (= "7888" (slurp f)) "existing file should be left alone"))
+      (finally
+        (.delete f)
+        (.delete (.toFile dir))))))
 
 (deftest bencode-safe-test
   (let [f #'bridge/bencode-safe]

--- a/test/drawbridge/core_test.clj
+++ b/test/drawbridge/core_test.clj
@@ -101,15 +101,26 @@
       (is (= [] messages))))
 
   (testing "GET retrieves deferred eval results via polling"
+    ;; The sleep guarantees the eval is still pending when the POST
+    ;; (read timeout 0) returns; on a warm JVM a bare (+ 5 6) can
+    ;; finish before the POST drains its responses.
     (let [handler (make-handler)
-          resp1 (handler (request :post {:op "eval" :code "(+ 5 6)"}))
+          resp1 (handler (request :post {:op "eval"
+                                         :code "(do (Thread/sleep 300) (+ 5 6))"}))
           cookie (extract-session-cookie resp1 "drawbridge-session")]
       (is (= [] (parse-body (:body resp1))))
-      (Thread/sleep 200)
-      (let [resp2 (handler (-> (request :get)
-                               (assoc-in [:headers "cookie"]
-                                         (str "drawbridge-session=" cookie))))
-            messages (parse-body (:body resp2))]
+      (let [deadline (+ (System/currentTimeMillis) 10000)
+            poll (fn []
+                   (parse-body
+                    (:body (handler (-> (request :get)
+                                        (assoc-in [:headers "cookie"]
+                                                  (str "drawbridge-session=" cookie)))))))
+            messages (loop []
+                       (let [msgs (poll)]
+                         (if (or (some #(= "11" (:value %)) msgs)
+                                 (> (System/currentTimeMillis) deadline))
+                           msgs
+                           (do (Thread/sleep 100) (recur)))))]
         (is (some #(= "11" (:value %)) messages))))))
 
 (deftest session-handling

--- a/test/drawbridge/core_test.clj
+++ b/test/drawbridge/core_test.clj
@@ -6,7 +6,9 @@
             [nrepl.transport :as transport]
             [ring.middleware.keyword-params :refer [wrap-keyword-params]]
             [ring.middleware.nested-params :refer [wrap-nested-params]]
-            [ring.middleware.params :refer [wrap-params]]))
+            [ring.middleware.params :refer [wrap-params]]
+            [ring.middleware.session :refer [wrap-session]]
+            [ring.middleware.session.memory :as mem]))
 
 (defn- make-handler
   [& opts]
@@ -128,6 +130,48 @@
           set-cookie (get-set-cookie resp)]
       (is (some? set-cookie))
       (is (re-find #"my-session=" set-cookie)))))
+
+;; Regression test for #11: early Drawbridge stored its transport in
+;; the application's shared ring session, clobbering the app's own
+;; session data. The handler now keeps its state in a private memory
+;; store under its own cookie, so an app-level session must survive
+;; REPL traffic untouched.
+(deftest app-ring-session-is-not-clobbered
+  (let [app-sessions (atom {})
+        drawbridge-handler (make-handler :default-read-timeout 5000)
+        handler (-> (fn [req]
+                      (if (= "/repl" (:uri req))
+                        (drawbridge-handler req)
+                        {:status 200
+                         :session (assoc (:session req) :user "bozhidar")
+                         :body (str (get-in req [:session :user]))}))
+                    (wrap-session {:store (mem/memory-store app-sessions)}))]
+    ;; establish an app session
+    (let [resp1 (handler {:request-method :get :uri "/app" :headers {}})
+          app-cookie (extract-session-cookie resp1 "ring-session")]
+      (is (some? app-cookie) "app session cookie should be set")
+
+      ;; hit the nREPL endpoint with the app session cookie attached
+      (let [resp2 (handler (-> (request :post {:op "eval" :code "(+ 1 2)"})
+                               (assoc-in [:headers "cookie"]
+                                         (str "ring-session=" app-cookie))))]
+        (is (= 200 (:status resp2)))
+        (testing "drawbridge answers with its own cookie, not the app's"
+          (let [set-cookie (or (get-set-cookie resp2) "")]
+            (is (re-find #"drawbridge-session=" set-cookie))
+            (is (not (re-find #"ring-session=" set-cookie))))))
+
+      (testing "the app session survives REPL traffic"
+        (let [resp3 (handler (-> {:request-method :get :uri "/app" :headers {}}
+                                 (assoc-in [:headers "cookie"]
+                                           (str "ring-session=" app-cookie))))]
+          (is (= "bozhidar" (:body resp3)))))
+
+      (testing "no drawbridge internals leak into the app session store"
+        (is (not-any? (fn [[_ session]]
+                        (some #(= "drawbridge.core" (namespace %))
+                              (filter keyword? (keys session))))
+                      @app-sessions))))))
 
 (deftest custom-nrepl-handler
   (testing "responses come from the supplied handler"

--- a/test/drawbridge/websocket_test.clj
+++ b/test/drawbridge/websocket_test.clj
@@ -168,8 +168,11 @@
         (.stop server)
         ;; The relay should notice the dead remote and close our
         ;; socket; a read on it then throws instead of hanging forever.
+        ;; The generous deadline only matters on failure -- success
+        ;; exits the loop at the first throw. Jetty's graceful stop
+        ;; plus WS close propagation can take a while on slow CI.
         (is (thrown? Exception
-                     (let [deadline (+ (System/currentTimeMillis) 10000)]
+                     (let [deadline (+ (System/currentTimeMillis) 60000)]
                        (loop []
                          (transport/recv conn 100)
                          (when (< (System/currentTimeMillis) deadline)

--- a/test/drawbridge/websocket_test.clj
+++ b/test/drawbridge/websocket_test.clj
@@ -179,6 +179,32 @@
           (try (.close conn) (catch Exception _))
           (bridge/stop-bridge b))))))
 
+(deftest websocket-keepalive-pings
+  (testing "the server pings idle connections and the client pongs back"
+    (let [pongs (atom 0)
+          base (websocket/ring-handler :ping-interval-ms 100)
+          handler (fn [req]
+                    (let [resp (base req)]
+                      (if-let [listener (:ring.websocket/listener resp)]
+                        (assoc resp :ring.websocket/listener
+                               (assoc listener
+                                      :on-pong (fn [_socket _data]
+                                                 (swap! pongs inc))))
+                        resp)))
+          server (jetty/run-jetty handler {:port 0 :join? false})
+          port (.getLocalPort (first (.getConnectors server)))]
+      (try
+        (with-open [conn (nrepl/url-connect (str "ws://localhost:" port "/"))]
+          (let [client (nrepl/client conn 20000)]
+            (is (= "3" (:value (send-message client {:op "eval" :code "(+ 1 2)"}))))
+            (is (await-value #(pos? @pongs) 5000)
+                "keepalive pings should be answered while the connection idles")
+            ;; the connection is still usable after idling across
+            ;; several ping intervals
+            (is (= "4" (:value (send-message client {:op "eval" :code "(+ 2 2)"}))))))
+        (finally
+          (.stop server))))))
+
 (deftest ws-client-uses-config-headers
   (testing "wss/ws transport falls back to the .nrepl.edn header config"
     (let [handler (auth/wrap-token (websocket/ring-handler) "cfg-secret")


### PR DESCRIPTION
A follow-up wave of small usability improvements now that the bridge, auth, and WebSocket transport have landed:

- The bridge CLI writes a `.nrepl-port` file (removed on exit) so `cider-connect` and friends auto-detect it, reads the token from `DRAWBRIDGE_TOKEN` (arguments leak via `ps`), gained `--help`, and rejects unknown flags instead of silently ignoring them. Connection failures now reach the connecting client as an in-band `:err` message, so the reason shows up in the REPL rather than only on the bridge's stderr.
- The WebSocket server pings idle connections every 30s so proxies (e.g. Heroku's ~55s router timeout) don't sever quiet REPL sessions. Relates to #46.
- A `deps.edn` makes Drawbridge consumable as a git dependency, including running the bridge straight from a git coordinate.
- A regression test proves the app-session clobbering reported in #11 is gone (the handler has kept its state in a private store for a while now). Fixes #11.

Also deflakes the deferred-eval polling test, which relied on a cold JVM. All exercised live: `--help`/bad-flag output, env-token bridge over WS, `.nrepl-port` written and cleaned up on SIGTERM, and the in-band error showing up in an nREPL session.